### PR TITLE
feat(tui): slim status bars and add help overlay

### DIFF
--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -195,6 +195,7 @@ public class TuiController {
     private final Set<String> selectedRecipes = new LinkedHashSet<>();
     private final Set<String> selectedTags = new LinkedHashSet<>();
     private boolean searchMode;
+    private boolean showHelp;
     private ExecutionResult executionResult;
     private boolean lastRunWasDryRun;
 
@@ -263,6 +264,14 @@ public class TuiController {
 
     public boolean isSearchMode() {
         return searchMode;
+    }
+
+    public boolean isShowHelp() {
+        return showHelp;
+    }
+
+    public void toggleHelp() {
+        this.showHelp = !this.showHelp;
     }
 
     // --- Browser list state (delegated to browserState) ---

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
@@ -32,9 +32,17 @@ public final class BrowserView {
     public static Element render(TuiController controller, AtunkoTui app) {
         List<DisplayRow> displayRows = controller.displayRows();
 
+        Element centerContent;
+        if (controller.isShowHelp()) {
+            centerContent = row(spacer(), HelpOverlay.render(HelpOverlay.BROWSER_HELP), spacer())
+                    .constraint(Constraint.fill());
+        } else {
+            centerContent = row(renderRecipeList(controller, displayRows), renderDetailPanel(controller))
+                    .constraint(Constraint.fill());
+        }
+
         return column(dock().top(renderHeader(controller), Constraint.length(3))
-                        .center(row(renderRecipeList(controller, displayRows), renderDetailPanel(controller))
-                                .constraint(Constraint.fill()))
+                        .center(centerContent)
                         .bottom(renderStatusBar(controller, displayRows), Constraint.length(1))
                         .constraint(Constraint.fill()))
                 .id("browser")
@@ -44,6 +52,10 @@ public final class BrowserView {
 
     private static EventResult handleKeyEvent(
             TuiController controller, AtunkoTui app, dev.tamboui.tui.event.KeyEvent event) {
+        if (controller.isShowHelp()) {
+            controller.toggleHelp();
+            return EventResult.HANDLED;
+        }
         if (controller.isSearchMode()) {
             return handleSearchModeKey(controller, event);
         }
@@ -126,6 +138,10 @@ public final class BrowserView {
         }
         if (event.isChar('s')) {
             controller.setSortOrder(controller.sortOrder() == SortOrder.NAME ? SortOrder.TAGS : SortOrder.NAME);
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('?')) {
+            controller.toggleHelp();
             return EventResult.HANDLED;
         }
         return EventResult.UNHANDLED;
@@ -214,11 +230,7 @@ public final class BrowserView {
     private static Element renderStatusBar(TuiController controller, List<DisplayRow> displayRows) {
         int selected = controller.selectedRecipes().size();
         long parentCount = displayRows.stream().filter(r -> !r.isSubRecipe()).count();
-        String status = parentCount + " recipes"
-                + " | " + selected + " selected"
-                + " | [x]=selected [c]=covered"
-                + " | \u2191\u2193:nav Space:sel a:all/none r:run Enter:detail"
-                + " \u2192:expand \u2190:collapse t:tags s:sort /:search Esc:clear q:quit";
+        String status = parentCount + " recipes | " + selected + " selected | ?:help q:quit";
         return text(" " + status).fg(Color.WHITE).bg(Color.indexed(236));
     }
 }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
@@ -29,7 +29,9 @@ public final class ConfirmRunView {
                 controller.projectDir().toAbsolutePath().normalize().toString();
 
         Element centerContent;
-        if (hasRecipes) {
+        if (controller.isShowHelp()) {
+            centerContent = row(spacer(), HelpOverlay.render(HelpOverlay.RUN_DIALOG_HELP), spacer());
+        } else if (hasRecipes) {
             centerContent = column(
                     row(text("Project: ").bold(), text(projectPath)),
                     text(""),
@@ -45,10 +47,7 @@ public final class ConfirmRunView {
                 .filter(r -> selected.contains(r.recipe().name()))
                 .count();
         long totalCount = displayRows.size();
-        String footer = hasRecipes
-                ? " \u2191\u2193:nav +/-:reorder Space:toggle a:sel all/none \u2192:expand \u2190:collapse f:flatten"
-                        + " r:run d:dry-run Esc:back"
-                : " Esc:back";
+        String footer = hasRecipes ? selectedCount + "/" + totalCount + " selected | ?:help Esc:back" : "Esc:back";
 
         return column(dock().top(
                                 row(
@@ -83,6 +82,14 @@ public final class ConfirmRunView {
 
     private static EventResult handleKeyEvent(
             TuiController controller, boolean hasRecipes, dev.tamboui.tui.event.KeyEvent event) {
+        if (controller.isShowHelp()) {
+            controller.toggleHelp();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('?')) {
+            controller.toggleHelp();
+            return EventResult.HANDLED;
+        }
         if (hasRecipes) {
             if (event.isDown()) {
                 controller.moveRunHighlightDown();

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
@@ -66,6 +66,13 @@ public final class DetailView {
                     text(String.join(", ", parents)).fg(Color.LIGHT_YELLOW)));
         }
 
+        Element centerContent;
+        if (controller.isShowHelp()) {
+            centerContent = row(spacer(), HelpOverlay.render(HelpOverlay.DETAIL_HELP), spacer());
+        } else {
+            centerContent = panel("Recipe Detail", detailContent).rounded().borderColor(Color.LIGHT_CYAN);
+        }
+
         return column(dock().top(
                                 row(
                                         text(" " + RecipeListRenderer.cleanDisplayName(recipe.displayName()))
@@ -75,9 +82,9 @@ public final class DetailView {
                                         spacer(),
                                         selectionLabel),
                                 Constraint.length(1))
-                        .center(panel("Recipe Detail", detailContent).rounded().borderColor(Color.LIGHT_CYAN))
+                        .center(centerContent)
                         .bottom(
-                                text(" Esc/q:back Space:toggle selection")
+                                text(" ?:help Space:toggle Esc/q:back")
                                         .fg(Color.WHITE)
                                         .bg(Color.indexed(236)),
                                 Constraint.length(1))
@@ -85,6 +92,14 @@ public final class DetailView {
                 .id("detail")
                 .focusable()
                 .onKeyEvent(event -> {
+                    if (controller.isShowHelp()) {
+                        controller.toggleHelp();
+                        return EventResult.HANDLED;
+                    }
+                    if (event.isChar('?')) {
+                        controller.toggleHelp();
+                        return EventResult.HANDLED;
+                    }
                     if (event.isChar('q') || event.code() == dev.tamboui.tui.event.KeyCode.ESCAPE) {
                         controller.goBack();
                         return EventResult.HANDLED;

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
@@ -1,0 +1,83 @@
+package io.github.atunkodev.tui.view;
+
+import static dev.tamboui.toolkit.Toolkit.column;
+import static dev.tamboui.toolkit.Toolkit.panel;
+import static dev.tamboui.toolkit.Toolkit.row;
+import static dev.tamboui.toolkit.Toolkit.text;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.style.Color;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.elements.Column;
+import java.util.List;
+
+public final class HelpOverlay {
+
+    public record Entry(String key, String description) {}
+
+    public record Section(String title, List<Entry> entries) {}
+
+    private HelpOverlay() {}
+
+    public static final List<Section> BROWSER_HELP = List.of(
+            new Section(
+                    "Navigation",
+                    List.of(
+                            new Entry("\u2191\u2193", "Move"),
+                            new Entry("\u2192", "Expand"),
+                            new Entry("\u2190", "Collapse"))),
+            new Section("Selection", List.of(new Entry("Space", "Toggle"), new Entry("a", "All/none"))),
+            new Section(
+                    "Actions",
+                    List.of(
+                            new Entry("Enter", "Detail view"),
+                            new Entry("r", "Run dialog"),
+                            new Entry("t", "Tag browser"),
+                            new Entry("s", "Sort order"),
+                            new Entry("/", "Search"),
+                            new Entry("Esc", "Clear all"),
+                            new Entry("q", "Quit"))),
+            new Section("Legend", List.of(new Entry("[x]", "Selected"), new Entry("[c]", "Covered by composite"))));
+
+    public static final List<Section> RUN_DIALOG_HELP = List.of(
+            new Section(
+                    "Navigation",
+                    List.of(
+                            new Entry("\u2191\u2193", "Move"),
+                            new Entry("+/-", "Reorder"),
+                            new Entry("\u2192", "Expand"),
+                            new Entry("\u2190", "Collapse"))),
+            new Section("Selection", List.of(new Entry("Space", "Toggle"), new Entry("a", "All/none"))),
+            new Section(
+                    "Actions",
+                    List.of(
+                            new Entry("r", "Run"),
+                            new Entry("d", "Dry-run"),
+                            new Entry("f", "Flatten"),
+                            new Entry("Esc", "Back"))));
+
+    public static final List<Section> DETAIL_HELP = List.of(
+            new Section("Actions", List.of(new Entry("Space", "Toggle selection"), new Entry("Esc/q", "Back"))));
+
+    public static Element render(List<Section> sections) {
+        Column cols = column();
+        for (Section section : sections) {
+            cols.add(text(" " + section.title()).bold().fg(Color.LIGHT_CYAN));
+            for (Entry entry : section.entries()) {
+                cols.add(row(text("  " + padRight(entry.key(), 8)).fg(Color.LIGHT_YELLOW), text(entry.description())));
+            }
+            cols.add(text(""));
+        }
+        return panel("Help — press any key to close", cols)
+                .rounded()
+                .borderColor(Color.LIGHT_CYAN)
+                .constraint(Constraint.percentage(60));
+    }
+
+    private static String padRight(String s, int width) {
+        if (s.length() >= width) {
+            return s;
+        }
+        return s + " ".repeat(width - s.length());
+    }
+}

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -975,6 +975,24 @@ class TuiControllerTest {
         assertThat(rows.get(7).depth()).isEqualTo(1);
     }
 
+    // --- Help Overlay ---
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001"})
+    void toggleHelp_togglesHelpState() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.isShowHelp()).isFalse();
+
+        controller.toggleHelp();
+
+        assertThat(controller.isShowHelp()).isTrue();
+
+        controller.toggleHelp();
+
+        assertThat(controller.isShowHelp()).isFalse();
+    }
+
     // --- Recipe Coverage Indicators ---
 
     @Test


### PR DESCRIPTION
## Summary

- Slim browser status bar from verbose keybinding dump to essentials: `N recipes | M selected | ?:help q:quit`
- Slim ConfirmRunView footer to `N/M selected | ?:help Esc:back`
- Slim DetailView footer to `?:help Space:toggle Esc/q:back`
- Add `HelpOverlay` utility that renders a centered panel with keybindings grouped by section (Navigation, Selection, Actions, Legend)
- Wire `?` key in BrowserView, ConfirmRunView, and DetailView — any key dismisses the overlay

## Test plan

- [x] `toggleHelp_togglesHelpState()` unit test added and passing
- [x] All existing tests pass (`./gradlew build`)
- [ ] Manual: verify slim status bars render correctly on narrow terminals
- [ ] Manual: `?` opens help overlay, any key closes it
- [ ] Manual: help overlay shows correct keybindings per view

🤖 Generated with [Claude Code](https://claude.com/claude-code)