### PR TITLE
test(tui): add debug logging test for SVC_TUI_0001.15

### DIFF
--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/AtunkoTuiTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/AtunkoTuiTest.java
@@ -1,0 +1,32 @@
+package io.github.atunkodev.tui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.reqstool.annotations.SVCs;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AtunkoTuiTest {
+
+    private static final RecipeInfo ALPHA =
+            new RecipeInfo("org.test.Alpha", "Alpha Recipe", "First recipe", Set.of("java"));
+    private static final List<RecipeInfo> RECIPES = List.of(ALPHA);
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.15"})
+    void logFile_configuresFileHandler(@TempDir Path tempDir) {
+        Path logFile = tempDir.resolve("debug.log");
+        TuiController controller = new TuiController(RECIPES);
+
+        new AtunkoTui(controller, logFile);
+
+        Logger logger = Logger.getLogger("io.github.atunkodev");
+        assertThat(logger.getLevel()).isNotNull();
+        assertThat(logger.getHandlers()).anyMatch(h -> h instanceof java.util.logging.FileHandler);
+    }
+}


### PR DESCRIPTION
## Summary
- Add missing test for SVC_TUI_0001.15 (debug logging file handler)
- Verifies AtunkoTui configures a FileHandler on the io.github.atunkodev logger when --log-file is provided

## Test plan
- [x] `./gradlew build` passes
- [x] `reqstool status` shows TUI_0001.15 green (was previously M1)