### PR TITLE
feat(tui): CSS theming via TamboUI TCSS stylesheets (TUI_0001.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,23 @@ The fat JAR is produced at `atunko-cli/build/libs/atunko.jar`.
 # Launch the interactive recipe browser (default command)
 java -jar atunko-cli/build/libs/atunko.jar tui
 
+# Launch with light theme
+java -jar atunko-cli/build/libs/atunko.jar tui --theme light
+
+# Launch with a custom CSS theme file
+java -jar atunko-cli/build/libs/atunko.jar tui --css-file ~/.config/atunko/mytheme.tcss
+
 # Launch with debug logging to a file
 java -jar atunko-cli/build/libs/atunko.jar tui --log-file tui.log
 ```
 
-Options: `--log-file <path>` — write TUI debug output to a file (useful for troubleshooting).
+Options:
+
+- `--theme <dark|light>` — select a bundled theme (default: `dark`)
+- `--css-file <path>` — load a custom TCSS theme file (overrides `--theme` and the XDG default)
+- `--log-file <path>` — write TUI debug output to a file (useful for troubleshooting)
+
+**Theme resolution order:** `--css-file` → `~/.config/atunko/theme.tcss` (XDG) → `--theme` → `dark`
 
 Key bindings:
 

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
@@ -1,6 +1,8 @@
 package io.github.atunkodev.tui;
 
+import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.toolkit.app.ToolkitApp;
+import dev.tamboui.toolkit.app.ToolkitRunner;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.error.ErrorAction;
@@ -22,14 +24,16 @@ public class AtunkoTui extends ToolkitApp {
 
     private final TuiController controller;
     private final Path logFile;
+    private final ThemeConfig themeConfig;
 
     public AtunkoTui(TuiController controller) {
-        this(controller, null);
+        this(controller, null, ThemeConfig.DEFAULT);
     }
 
-    public AtunkoTui(TuiController controller, Path logFile) {
+    public AtunkoTui(TuiController controller, Path logFile, ThemeConfig themeConfig) {
         this.controller = controller;
         this.logFile = logFile;
+        this.themeConfig = themeConfig;
         if (logFile != null) {
             configureLogging(logFile);
         }
@@ -59,8 +63,34 @@ public class AtunkoTui extends ToolkitApp {
         return TuiConfig.defaults();
     }
 
+    @Override
+    public void run() throws Exception {
+        StyleEngine styleEngine = createStyleEngine();
+        try (ToolkitRunner r = ToolkitRunner.builder()
+                .config(configure())
+                .styleEngine(styleEngine)
+                .build()) {
+            onStart();
+            r.run(this::render);
+        } finally {
+            onStop();
+        }
+    }
+
     public void requestQuit() {
         quit();
+    }
+
+    private StyleEngine createStyleEngine() throws IOException {
+        StyleEngine engine = StyleEngine.create();
+        if (themeConfig.isUserCss()) {
+            engine.loadStylesheet(themeConfig.cssFile());
+        } else {
+            engine.loadStylesheet("dark", "/themes/dark.tcss");
+            engine.loadStylesheet("light", "/themes/light.tcss");
+            engine.setActiveStylesheet(themeConfig.themeName());
+        }
+        return engine;
     }
 
     private static void configureLogging(Path logFile) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/ThemeConfig.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/ThemeConfig.java
@@ -1,0 +1,51 @@
+package io.github.atunkodev.tui;
+
+import java.nio.file.Path;
+
+/**
+ * Theme configuration resolved from CLI flags and XDG defaults.
+ *
+ * @param themeName the bundled theme name ("dark" or "light"), null if user CSS overrides
+ * @param cssFile path to a user-provided CSS file, null if using a bundled theme
+ */
+public record ThemeConfig(String themeName, Path cssFile) {
+
+    /** Default theme configuration — dark theme, no user CSS. */
+    public static final ThemeConfig DEFAULT = new ThemeConfig("dark", null);
+
+    private static final Path XDG_THEME_PATH =
+            Path.of(System.getProperty("user.home"), ".config", "atunko", "theme.tcss");
+
+    /**
+     * Resolves a ThemeConfig from CLI options.
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>{@code --css-file} flag — user-provided CSS replaces bundled theme</li>
+     *   <li>{@code ~/.config/atunko/theme.tcss} exists — auto-loaded, replaces bundled</li>
+     *   <li>{@code --theme} flag — selects bundled theme</li>
+     *   <li>Default — dark theme</li>
+     * </ol>
+     */
+    public static ThemeConfig resolve(String themeName, Path cssFile) {
+        return resolve(themeName, cssFile, XDG_THEME_PATH);
+    }
+
+    static ThemeConfig resolve(String themeName, Path cssFile, Path xdgThemePath) {
+        if (cssFile != null) {
+            return new ThemeConfig(null, cssFile);
+        }
+        if (xdgThemePath.toFile().isFile()) {
+            return new ThemeConfig(null, xdgThemePath);
+        }
+        if (themeName != null) {
+            return new ThemeConfig(themeName, null);
+        }
+        return DEFAULT;
+    }
+
+    /** Returns true if a user-provided CSS file should be used instead of a bundled theme. */
+    public boolean isUserCss() {
+        return cssFile != null;
+    }
+}

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiCommand.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiCommand.java
@@ -29,6 +29,12 @@ public class TuiCommand implements Runnable {
     @Option(names = "--log-file", description = "Log file for TUI debug output")
     private Path logFile;
 
+    @Option(names = "--theme", description = "Theme name: dark (default), light")
+    private String theme;
+
+    @Option(names = "--css-file", description = "Path to a custom CSS theme file (replaces bundled theme)")
+    private Path cssFile;
+
     public TuiCommand(
             RecipeDiscoveryService discoveryService,
             RunConfigService runConfigService,
@@ -49,7 +55,8 @@ public class TuiCommand implements Runnable {
         List<RecipeInfo> recipes = discoveryService.discoverAll();
         TuiController controller =
                 new TuiController(recipes, runConfigService, engine, sourceParser, changeApplier, projectDir);
-        AtunkoTui tui = new AtunkoTui(controller, logFile);
+        ThemeConfig themeConfig = ThemeConfig.resolve(theme, cssFile);
+        AtunkoTui tui = new AtunkoTui(controller, logFile, themeConfig);
         try {
             tui.run();
         } catch (Exception e) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
@@ -11,7 +11,6 @@ import static dev.tamboui.toolkit.Toolkit.text;
 import static dev.tamboui.toolkit.Toolkit.textInput;
 
 import dev.tamboui.layout.Constraint;
-import dev.tamboui.style.Color;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
 import dev.tamboui.widgets.input.TextInputState;
@@ -46,6 +45,7 @@ public final class BrowserView {
                         .bottom(renderStatusBar(controller, displayRows), Constraint.length(1))
                         .constraint(Constraint.fill()))
                 .id("browser")
+                .addClass("app")
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, app, event));
     }
@@ -172,13 +172,12 @@ public final class BrowserView {
             SEARCH_STATE.setText(controller.searchQuery());
         }
         var headerLabel = controller.isSearchMode()
-                ? text(" SEARCH ").bold().fg(Color.BLACK).bg(Color.LIGHT_YELLOW)
-                : text(" atunko ").bold().fg(Color.WHITE).bg(Color.BLUE);
+                ? text(" SEARCH ").addClass("screen-title", "search-mode")
+                : text(" atunko ").addClass("screen-title");
         var tagIndicator = controller.selectedTags().isEmpty()
                 ? spacer()
                 : text(" tags:" + String.join(",", controller.selectedTags()) + " ")
-                        .fg(Color.BLACK)
-                        .bg(Color.LIGHT_CYAN);
+                        .addClass("tag-indicator");
         return row(
                 headerLabel,
                 text(" "),
@@ -215,36 +214,31 @@ public final class BrowserView {
                 .map(recipe -> {
                     var content = column(
                             text(RecipeListRenderer.cleanDisplayName(recipe.displayName()))
-                                    .bold()
-                                    .fg(Color.LIGHT_CYAN),
+                                    .addClass("recipe-name"),
                             text(""),
-                            text(recipe.name()).dim(),
+                            text(recipe.name()).addClass("unselected"),
                             text(""),
                             text(recipe.description() != null ? recipe.description() : ""),
                             text(""),
                             row(
-                                    text("Tags: ").bold(),
+                                    text("Tags: ").addClass("detail-label"),
                                     text(recipe.tags().isEmpty() ? "none" : String.join(", ", recipe.tags()))
-                                            .fg(Color.LIGHT_CYAN)),
+                                            .addClass("detail-value")),
                             recipe.isComposite()
                                     ? text("Composite: " + recipe.recipeList().size() + " sub-recipes")
-                                            .fg(Color.LIGHT_CYAN)
+                                            .addClass("detail-value")
                                     : text(""));
                     java.util.List<String> parents = controller.includedIn(recipe.name());
                     if (!parents.isEmpty()) {
                         content.add(text(""));
                         content.add(row(
-                                text("Included in: ").bold().fg(Color.LIGHT_YELLOW),
-                                text(String.join(", ", parents)).fg(Color.LIGHT_YELLOW)));
+                                text("Included in: ").addClass("detail-label", "included-in"),
+                                text(String.join(", ", parents)).addClass("included-in")));
                     }
-                    return (Element) panel("Detail", content)
-                            .rounded()
-                            .borderColor(Color.LIGHT_CYAN)
-                            .constraint(Constraint.fill(1));
+                    return (Element) panel("Detail", content).addClass("panel").constraint(Constraint.fill(1));
                 })
                 .orElse(panel("Detail", text("No recipe selected"))
-                        .rounded()
-                        .borderColor(Color.LIGHT_CYAN)
+                        .addClass("panel")
                         .constraint(Constraint.fill(1)));
     }
 
@@ -252,6 +246,6 @@ public final class BrowserView {
         int selected = controller.selectedRecipes().size();
         long parentCount = displayRows.stream().filter(r -> !r.isSubRecipe()).count();
         String status = parentCount + " recipes | " + selected + " selected | ?:help q:quit";
-        return text(" " + status).fg(Color.WHITE).bg(Color.indexed(236));
+        return text(" " + status).addClass("status-bar");
     }
 }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
@@ -7,7 +7,6 @@ import static dev.tamboui.toolkit.Toolkit.spacer;
 import static dev.tamboui.toolkit.Toolkit.text;
 
 import dev.tamboui.layout.Constraint;
-import dev.tamboui.style.Color;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
 import io.github.atunkodev.tui.TuiController;
@@ -33,13 +32,13 @@ public final class ConfirmRunView {
             centerContent = row(spacer(), HelpOverlay.render(HelpOverlay.RUN_DIALOG_HELP), spacer());
         } else if (hasRecipes) {
             centerContent = column(
-                    row(text("Project: ").bold(), text(projectPath)),
+                    row(text("Project: ").addClass("detail-label"), text(projectPath)),
                     text(""),
                     renderRecipeList(controller, displayRows, selected));
         } else {
             centerContent = column(
                     text(""),
-                    text(" No recipes selected.").bold().fg(Color.LIGHT_YELLOW),
+                    text(" No recipes selected.").addClass("warning"),
                     text(" Use Space to select recipes, then press r to run."));
         }
 
@@ -51,16 +50,13 @@ public final class ConfirmRunView {
 
         return column(dock().top(
                                 row(
-                                        text(" Run Recipes ")
-                                                .bold()
-                                                .fg(Color.WHITE)
-                                                .bg(Color.BLUE),
+                                        text(" Run Recipes ").addClass("screen-title"),
                                         spacer(),
                                         text(selectedCount + "/" + totalCount + " selected ")
-                                                .fg(Color.LIGHT_GREEN)),
+                                                .addClass("coverage-indicator")),
                                 Constraint.length(1))
                         .center(centerContent)
-                        .bottom(text(" " + footer).fg(Color.WHITE).bg(Color.indexed(236)), Constraint.length(1))
+                        .bottom(text(" " + footer).addClass("status-bar"), Constraint.length(1))
                         .constraint(Constraint.fill()))
                 .id("confirm-run")
                 .focusable()

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
@@ -8,7 +8,6 @@ import static dev.tamboui.toolkit.Toolkit.spacer;
 import static dev.tamboui.toolkit.Toolkit.text;
 
 import dev.tamboui.layout.Constraint;
-import dev.tamboui.style.Color;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
 import io.github.atunkodev.core.recipe.RecipeInfo;
@@ -31,29 +30,31 @@ public final class DetailView {
     private static Element renderRecipeDetail(TuiController controller, RecipeInfo recipe) {
         boolean selected = controller.selectedRecipes().contains(recipe.name());
         var selectionLabel = selected
-                ? text("Selected ").fg(Color.LIGHT_GREEN)
-                : text("Not selected ").dim();
+                ? text("Selected ").addClass("selected")
+                : text("Not selected ").addClass("unselected");
 
         var detailContent = column(
-                row(text("Name: ").bold(), text(recipe.name())),
-                row(text("Display Name: ").bold(), text(RecipeListRenderer.cleanDisplayName(recipe.displayName()))),
+                row(text("Name: ").addClass("detail-label"), text(recipe.name())),
+                row(
+                        text("Display Name: ").addClass("detail-label"),
+                        text(RecipeListRenderer.cleanDisplayName(recipe.displayName()))),
                 text(""),
-                text("Description:").bold(),
+                text("Description:").addClass("detail-label"),
                 text(recipe.description() != null ? recipe.description() : "(none)"),
                 text(""),
-                text("Tags:").bold(),
+                text("Tags:").addClass("detail-label"),
                 text(recipe.tags().isEmpty() ? "(none)" : String.join(", ", recipe.tags()))
-                        .fg(Color.LIGHT_CYAN));
+                        .addClass("detail-value"));
 
         if (recipe.isComposite()) {
             detailContent.add(text(""));
-            detailContent.add(text("Recipe List:").bold());
+            detailContent.add(text("Recipe List:").addClass("detail-label"));
             int index = 1;
             for (RecipeInfo sub : recipe.recipeList()) {
                 detailContent.add(row(
-                        text("  " + index + ". ").fg(Color.LIGHT_YELLOW),
+                        text("  " + index + ". ").addClass("included-in"),
                         text(RecipeListRenderer.cleanDisplayName(sub.displayName()))
-                                .fg(Color.LIGHT_CYAN)));
+                                .addClass("detail-value")));
                 index++;
             }
         }
@@ -62,32 +63,26 @@ public final class DetailView {
         if (!parents.isEmpty()) {
             detailContent.add(text(""));
             detailContent.add(row(
-                    text("Included in: ").bold().fg(Color.LIGHT_YELLOW),
-                    text(String.join(", ", parents)).fg(Color.LIGHT_YELLOW)));
+                    text("Included in: ").addClass("detail-label", "included-in"),
+                    text(String.join(", ", parents)).addClass("included-in")));
         }
 
         Element centerContent;
         if (controller.isShowHelp()) {
             centerContent = row(spacer(), HelpOverlay.render(HelpOverlay.DETAIL_HELP), spacer());
         } else {
-            centerContent = panel("Recipe Detail", detailContent).rounded().borderColor(Color.LIGHT_CYAN);
+            centerContent = panel("Recipe Detail", detailContent).addClass("panel");
         }
 
         return column(dock().top(
                                 row(
                                         text(" " + RecipeListRenderer.cleanDisplayName(recipe.displayName()))
-                                                .bold()
-                                                .fg(Color.WHITE)
-                                                .bg(Color.BLUE),
+                                                .addClass("screen-title"),
                                         spacer(),
                                         selectionLabel),
                                 Constraint.length(1))
                         .center(centerContent)
-                        .bottom(
-                                text(" ?:help Space:toggle Esc/q:back")
-                                        .fg(Color.WHITE)
-                                        .bg(Color.indexed(236)),
-                                Constraint.length(1))
+                        .bottom(text(" ?:help Space:toggle Esc/q:back").addClass("status-bar"), Constraint.length(1))
                         .constraint(Constraint.fill()))
                 .id("detail")
                 .focusable()

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
@@ -8,8 +8,6 @@ import static dev.tamboui.toolkit.Toolkit.spacer;
 import static dev.tamboui.toolkit.Toolkit.text;
 
 import dev.tamboui.layout.Constraint;
-import dev.tamboui.style.Color;
-import dev.tamboui.style.Style;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
 import io.github.atunkodev.core.engine.ExecutionResult;
@@ -39,25 +37,17 @@ public final class ExecutionResultsView {
         String summary = changes.size() + " file(s) " + (controller.lastRunWasDryRun() ? "would change" : "changed");
 
         var titleElement = controller.lastRunWasDryRun()
-                ? text(" " + title + " ").bold().fg(Color.BLACK).bg(Color.LIGHT_YELLOW)
-                : text(" " + title + " ").bold().fg(Color.WHITE).bg(Color.LIGHT_GREEN);
+                ? text(" " + title + " ").addClass("screen-title", "dryrun-mode")
+                : text(" " + title + " ").addClass("screen-title", "success-mode");
 
         return column(dock().top(
-                                row(
-                                        titleElement,
-                                        spacer(),
-                                        text(summary + " ").bold().fg(Color.LIGHT_GREEN)),
+                                row(titleElement, spacer(), text(summary + " ").addClass("coverage-indicator")),
                                 Constraint.length(1))
                         .center(list(items)
                                 .title("Changed Files")
-                                .rounded()
-                                .borderColor(Color.LIGHT_CYAN)
-                                .highlightStyle(Style.EMPTY
-                                        .fg(Color.WHITE)
-                                        .bg(Color.BLUE)
-                                        .bold())
+                                .addClass("panel")
                                 .autoScroll())
-                        .bottom(text(" Esc/q:back").fg(Color.WHITE).bg(Color.indexed(236)), Constraint.length(1))
+                        .bottom(text(" Esc/q:back").addClass("status-bar"), Constraint.length(1))
                         .constraint(Constraint.fill()))
                 .id("execution-results")
                 .focusable()

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
@@ -6,7 +6,6 @@ import static dev.tamboui.toolkit.Toolkit.row;
 import static dev.tamboui.toolkit.Toolkit.text;
 
 import dev.tamboui.layout.Constraint;
-import dev.tamboui.style.Color;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.elements.Column;
 import java.util.List;
@@ -75,16 +74,13 @@ public final class HelpOverlay {
     public static Element render(List<Section> sections) {
         Column cols = column();
         for (Section section : sections) {
-            cols.add(text(" " + section.title()).bold().fg(Color.LIGHT_CYAN));
+            cols.add(text(" " + section.title()).addClass("help-title"));
             for (Entry entry : section.entries()) {
-                cols.add(row(text("  " + padRight(entry.key(), 8)).fg(Color.LIGHT_YELLOW), text(entry.description())));
+                cols.add(row(text("  " + padRight(entry.key(), 8)).addClass("help-key"), text(entry.description())));
             }
             cols.add(text(""));
         }
-        return panel("Help — press any key to close", cols)
-                .rounded()
-                .borderColor(Color.LIGHT_CYAN)
-                .constraint(Constraint.percentage(60));
+        return panel("Help — press any key to close", cols).addClass("panel").constraint(Constraint.percentage(60));
     }
 
     private static String padRight(String s, int width) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeListRenderer.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeListRenderer.java
@@ -6,8 +6,6 @@ import static dev.tamboui.toolkit.Toolkit.spacer;
 import static dev.tamboui.toolkit.Toolkit.text;
 
 import dev.tamboui.layout.Constraint;
-import dev.tamboui.style.Color;
-import dev.tamboui.style.Style;
 import dev.tamboui.toolkit.element.Element;
 import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.tui.TuiController.DisplayRow;
@@ -35,8 +33,7 @@ public final class RecipeListRenderer {
             String title,
             RenderOptions options,
             Constraint constraint) {
-        var recipeList =
-                list().highlightStyle(Style.EMPTY.fg(Color.WHITE).bg(Color.BLUE).bold());
+        var recipeList = list().addClass("list-item");
 
         int parentIndex = 0;
         for (DisplayRow displayRow : displayRows) {
@@ -64,7 +61,7 @@ public final class RecipeListRenderer {
             var nameEl = resolveNameStyle(displayName, selected, partial, covered, options);
 
             if (options.showTags() && !r.tags().isEmpty() && !displayRow.isSubRecipe()) {
-                var tags = text("  " + String.join(", ", r.tags())).dim();
+                var tags = text("  " + String.join(", ", r.tags())).addClass("tag");
                 recipeList.add(row(prefixEl, nameEl, spacer(), tags));
             } else {
                 recipeList.add(row(prefixEl, nameEl));
@@ -74,8 +71,7 @@ public final class RecipeListRenderer {
         var result = recipeList
                 .selected(highlightedIndex)
                 .title(title)
-                .rounded()
-                .borderColor(Color.LIGHT_CYAN)
+                .addClass("panel")
                 .autoScroll();
 
         if (constraint != null) {
@@ -96,21 +92,21 @@ public final class RecipeListRenderer {
 
     private static Element resolvePrefixStyle(String prefix, boolean selected, boolean partial, boolean covered) {
         if (selected || covered) {
-            return text(prefix).fg(Color.LIGHT_GREEN);
+            return text(prefix).addClass("selected");
         }
         if (partial) {
-            return text(prefix).fg(Color.YELLOW);
+            return text(prefix).addClass("partial");
         }
-        return text(prefix).dim();
+        return text(prefix).addClass("unselected");
     }
 
     private static Element resolveNameStyle(
             String displayName, boolean selected, boolean partial, boolean covered, RenderOptions options) {
         if (options.dimUnselected() && !selected && !covered) {
-            return text(displayName).dim();
+            return text(displayName).addClass("unselected");
         }
         if (!selected && !covered && !partial) {
-            return text(displayName).dim();
+            return text(displayName).addClass("unselected");
         }
         return text(displayName);
     }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
@@ -10,8 +10,6 @@ import static dev.tamboui.toolkit.Toolkit.text;
 import static dev.tamboui.toolkit.Toolkit.textInput;
 
 import dev.tamboui.layout.Constraint;
-import dev.tamboui.style.Color;
-import dev.tamboui.style.Style;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
 import dev.tamboui.widgets.input.TextInputState;
@@ -41,24 +39,23 @@ public final class TagBrowserView {
 
         Set<String> selected = controller.selectedTags();
 
-        var recipeList =
-                list().highlightStyle(Style.EMPTY.fg(Color.WHITE).bg(Color.BLUE).bold());
+        var recipeList = list().addClass("list-item");
         for (String tag : tags) {
             boolean isSelected = selected.contains(tag);
             String prefix = isSelected ? "[x] " : "[ ] ";
             var prefixEl = isSelected
-                    ? text(prefix).fg(Color.LIGHT_GREEN)
-                    : text(prefix).dim();
+                    ? text(prefix).addClass("selected")
+                    : text(prefix).addClass("unselected");
             recipeList.add(row(prefixEl, text(tag)));
         }
 
         var headerLabel = tagSearchMode
-                ? text(" SEARCH TAGS ").bold().fg(Color.BLACK).bg(Color.LIGHT_YELLOW)
-                : text(" Tag Browser ").bold().fg(Color.WHITE).bg(Color.BLUE);
+                ? text(" SEARCH TAGS ").addClass("screen-title", "search-mode")
+                : text(" Tag Browser ").addClass("screen-title");
 
         long selectedCount = selected.size();
         var selectedIndicator =
-                selectedCount > 0 ? text(" " + selectedCount + " selected ").fg(Color.LIGHT_GREEN) : text("");
+                selectedCount > 0 ? text(" " + selectedCount + " selected ").addClass("coverage-indicator") : text("");
 
         Element header = row(
                 headerLabel,
@@ -80,10 +77,9 @@ public final class TagBrowserView {
                         .center(recipeList
                                 .selected(tagIndex)
                                 .title("Tags (" + tags.size() + ")")
-                                .rounded()
-                                .borderColor(Color.LIGHT_CYAN)
+                                .addClass("panel")
                                 .autoScroll())
-                        .bottom(text(" " + footer).fg(Color.WHITE).bg(Color.indexed(236)), Constraint.length(1))
+                        .bottom(text(" " + footer).addClass("status-bar"), Constraint.length(1))
                         .constraint(Constraint.fill()))
                 .id("tag-browser")
                 .focusable()

--- a/atunko-tui/src/main/resources/themes/dark.tcss
+++ b/atunko-tui/src/main/resources/themes/dark.tcss
@@ -1,0 +1,138 @@
+/* atunko dark theme — default */
+
+/* Palette variables */
+$bg-primary: indexed(236);
+$fg-primary: white;
+$fg-accent: light-cyan;
+$fg-success: light-green;
+$fg-warning: light-yellow;
+$fg-partial: yellow;
+$bg-title: blue;
+$bg-highlight: blue;
+$bg-title-search: light-yellow;
+$bg-title-success: light-green;
+$bg-title-dryrun: light-yellow;
+
+/* Root */
+.app {
+    background: $bg-primary;
+    color: $fg-primary;
+}
+
+/* Screen title bar */
+.screen-title {
+    color: white;
+    background: $bg-title;
+    text-style: bold;
+}
+
+.screen-title.search-mode {
+    color: black;
+    background: $bg-title-search;
+}
+
+.screen-title.success-mode {
+    color: white;
+    background: $bg-title-success;
+}
+
+.screen-title.dryrun-mode {
+    color: black;
+    background: $bg-title-dryrun;
+}
+
+/* Status bar / footer */
+.status-bar {
+    color: white;
+    background: $bg-primary;
+}
+
+/* Panel borders */
+.panel {
+    border-type: rounded;
+    border-color: $fg-accent;
+}
+
+/* List highlight (selected/focused row) */
+.list-item:selected {
+    color: white;
+    background: $bg-highlight;
+    text-style: bold;
+}
+
+/* Recipe list selected prefix [x] */
+.selected {
+    color: $fg-success;
+}
+
+/* Recipe list partial prefix [~] */
+.partial {
+    color: $fg-partial;
+}
+
+/* Recipe list unselected / dim */
+.unselected {
+    text-style: dim;
+}
+
+/* Section headers */
+.section-header {
+    text-style: bold;
+}
+
+/* Recipe name */
+.recipe-name {
+    color: $fg-accent;
+}
+
+/* Recipe description */
+.recipe-description {
+    color: $fg-primary;
+}
+
+/* Tags */
+.tag {
+    text-style: dim;
+}
+
+/* Coverage / summary count */
+.coverage-indicator {
+    color: $fg-success;
+    text-style: bold;
+}
+
+/* Help overlay */
+.help-title {
+    color: $fg-accent;
+    text-style: bold;
+}
+
+.help-key {
+    color: $fg-warning;
+}
+
+/* Warning / empty state */
+.warning {
+    color: $fg-warning;
+    text-style: bold;
+}
+
+/* Tag indicator (browser) */
+.tag-indicator {
+    color: black;
+    background: $fg-accent;
+}
+
+/* Detail view labels */
+.detail-label {
+    text-style: bold;
+}
+
+.detail-value {
+    color: $fg-accent;
+}
+
+/* Included-in / coverage info */
+.included-in {
+    color: $fg-warning;
+}

--- a/atunko-tui/src/main/resources/themes/light.tcss
+++ b/atunko-tui/src/main/resources/themes/light.tcss
@@ -1,0 +1,138 @@
+/* atunko light theme */
+
+/* Palette variables */
+$bg-primary: white;
+$fg-primary: black;
+$fg-accent: rgb(0, 128, 128);
+$fg-success: rgb(0, 128, 0);
+$fg-warning: rgb(180, 120, 0);
+$fg-partial: rgb(180, 120, 0);
+$bg-title: rgb(0, 100, 180);
+$bg-highlight: rgb(0, 100, 180);
+$bg-title-search: rgb(255, 220, 100);
+$bg-title-success: rgb(0, 160, 0);
+$bg-title-dryrun: rgb(255, 220, 100);
+
+/* Root */
+.app {
+    background: $bg-primary;
+    color: $fg-primary;
+}
+
+/* Screen title bar */
+.screen-title {
+    color: white;
+    background: $bg-title;
+    text-style: bold;
+}
+
+.screen-title.search-mode {
+    color: black;
+    background: $bg-title-search;
+}
+
+.screen-title.success-mode {
+    color: white;
+    background: $bg-title-success;
+}
+
+.screen-title.dryrun-mode {
+    color: black;
+    background: $bg-title-dryrun;
+}
+
+/* Status bar / footer */
+.status-bar {
+    color: $fg-primary;
+    background: rgb(230, 230, 230);
+}
+
+/* Panel borders */
+.panel {
+    border-type: rounded;
+    border-color: $fg-accent;
+}
+
+/* List highlight (selected/focused row) */
+.list-item:selected {
+    color: white;
+    background: $bg-highlight;
+    text-style: bold;
+}
+
+/* Recipe list selected prefix [x] */
+.selected {
+    color: $fg-success;
+}
+
+/* Recipe list partial prefix [~] */
+.partial {
+    color: $fg-partial;
+}
+
+/* Recipe list unselected / dim */
+.unselected {
+    text-style: dim;
+}
+
+/* Section headers */
+.section-header {
+    text-style: bold;
+}
+
+/* Recipe name */
+.recipe-name {
+    color: $fg-accent;
+}
+
+/* Recipe description */
+.recipe-description {
+    color: $fg-primary;
+}
+
+/* Tags */
+.tag {
+    text-style: dim;
+}
+
+/* Coverage / summary count */
+.coverage-indicator {
+    color: $fg-success;
+    text-style: bold;
+}
+
+/* Help overlay */
+.help-title {
+    color: $fg-accent;
+    text-style: bold;
+}
+
+.help-key {
+    color: $fg-warning;
+}
+
+/* Warning / empty state */
+.warning {
+    color: $fg-warning;
+    text-style: bold;
+}
+
+/* Tag indicator (browser) */
+.tag-indicator {
+    color: white;
+    background: $fg-accent;
+}
+
+/* Detail view labels */
+.detail-label {
+    text-style: bold;
+}
+
+.detail-value {
+    color: $fg-accent;
+}
+
+/* Included-in / coverage info */
+.included-in {
+    color: $fg-warning;
+}

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/AtunkoTuiTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/AtunkoTuiTest.java
@@ -23,7 +23,7 @@ class AtunkoTuiTest {
         Path logFile = tempDir.resolve("debug.log");
         TuiController controller = new TuiController(RECIPES);
 
-        new AtunkoTui(controller, logFile);
+        new AtunkoTui(controller, logFile, ThemeConfig.DEFAULT);
 
         Logger logger = Logger.getLogger("io.github.atunkodev");
         assertThat(logger.getLevel()).isNotNull();

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/ThemeConfigTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/ThemeConfigTest.java
@@ -1,0 +1,100 @@
+package io.github.atunkodev.tui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.reqstool.annotations.SVCs;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ThemeConfigTest {
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.18"})
+    void defaultThemeIsDark() {
+        ThemeConfig config = ThemeConfig.resolve(null, null);
+
+        assertThat(config.themeName()).isEqualTo("dark");
+        assertThat(config.isUserCss()).isFalse();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.18.1", "atunko:SVC_TUI_0001.18.4"})
+    void themeFlagSelectsLight() {
+        ThemeConfig config = ThemeConfig.resolve("light", null);
+
+        assertThat(config.themeName()).isEqualTo("light");
+        assertThat(config.isUserCss()).isFalse();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.18.2"})
+    void cssFileFlagOverridesBundledTheme(@TempDir Path tempDir) throws IOException {
+        Path userCss = tempDir.resolve("custom.tcss");
+        Files.writeString(userCss, ".app { background: red; }");
+
+        ThemeConfig config = ThemeConfig.resolve("light", userCss);
+
+        assertThat(config.isUserCss()).isTrue();
+        assertThat(config.cssFile()).isEqualTo(userCss);
+        assertThat(config.themeName()).isNull();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.18.4"})
+    void themeFlagSelectsDark() {
+        ThemeConfig config = ThemeConfig.resolve("dark", null);
+
+        assertThat(config.themeName()).isEqualTo("dark");
+        assertThat(config.isUserCss()).isFalse();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.18.2"})
+    void cssFileTakesPriorityOverThemeFlag(@TempDir Path tempDir) throws IOException {
+        Path userCss = tempDir.resolve("theme.tcss");
+        Files.writeString(userCss, ".app { color: white; }");
+
+        ThemeConfig config = ThemeConfig.resolve("dark", userCss);
+
+        assertThat(config.isUserCss()).isTrue();
+        assertThat(config.cssFile()).isEqualTo(userCss);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.18.3"})
+    void xdgConfigFileAutoLoaded(@TempDir Path tempDir) throws IOException {
+        Path xdgTheme = tempDir.resolve("theme.tcss");
+        Files.writeString(xdgTheme, ".app { background: blue; }");
+
+        ThemeConfig config = ThemeConfig.resolve(null, null, xdgTheme);
+
+        assertThat(config.isUserCss()).isTrue();
+        assertThat(config.cssFile()).isEqualTo(xdgTheme);
+    }
+
+    @Test
+    void cssFileTakesPriorityOverXdgConfig(@TempDir Path tempDir) throws IOException {
+        Path xdgTheme = tempDir.resolve("xdg-theme.tcss");
+        Files.writeString(xdgTheme, ".app { background: blue; }");
+        Path userCss = tempDir.resolve("custom.tcss");
+        Files.writeString(userCss, ".app { background: red; }");
+
+        ThemeConfig config = ThemeConfig.resolve(null, userCss, xdgTheme);
+
+        assertThat(config.cssFile()).isEqualTo(userCss);
+    }
+
+    @Test
+    void cssFileReplacesNotLayers(@TempDir Path tempDir) throws IOException {
+        Path userCss = tempDir.resolve("theme.tcss");
+        Files.writeString(userCss, ".app { color: green; }");
+
+        ThemeConfig config = ThemeConfig.resolve(null, userCss);
+
+        assertThat(config.isUserCss()).isTrue();
+        assertThat(config.themeName()).isNull();
+    }
+}

--- a/docs/antora/modules/ROOT/pages/cli.adoc
+++ b/docs/antora/modules/ROOT/pages/cli.adoc
@@ -27,9 +27,33 @@ atunko        # same as above — tui is the default
 | Project directory for recipe execution (default: `.`). Uses the Gradle Tooling API to
 resolve source dirs, resource dirs, test dirs, and compile classpath for each module.
 
+| `--theme <dark\|light>`
+| Select a bundled colour theme (default: `dark`).
+
+| `--css-file <path>`
+| Load a custom TCSS theme file. Overrides `--theme` and the XDG default
+(`~/.config/atunko/theme.tcss`).
+
 | `--log-file <path>`
 | Write TUI debug output to a file (useful for troubleshooting)
 |===
+
+==== Theming
+
+The TUI ships with bundled `dark` and `light` themes and supports user-provided TCSS stylesheets.
+
+Theme resolution order:
+
+. `--css-file <path>` — explicit file path (highest priority)
+. `~/.config/atunko/theme.tcss` — XDG config auto-load (if the file exists)
+. `--theme <dark|light>` — bundled theme selection
+. `dark` — built-in default
+
+[source,bash]
+----
+atunko tui --theme light
+atunko tui --css-file ~/.config/atunko/mytheme.tcss
+----
 
 ==== Browser key bindings
 

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -384,6 +384,18 @@ requirements:
     categories: [interaction-capability]
     revision: 0.1.0
 
+  - id: TUI_0001.18
+    title: TUI — CSS Theming
+    significance: shall
+    description: >-
+      The TUI shall support CSS-based theming via TamboUI TCSS stylesheets,
+      shipping bundled dark and light themes, with user-provided CSS file support
+      and theme selection via --theme CLI flag
+    references:
+      requirement_ids: ["TUI_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
   # CLI requirements — list/search/run
   - id: CLI_0002
     title: CLI Recipe Listing

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -659,6 +659,56 @@ cases:
       THEN the composite is tracked in the partial (indeterminate) set and rendered with an indeterminate indicator
     revision: "0.1.0"
 
+  - id: SVC_TUI_0001.18
+    requirement_ids: ["TUI_0001.18"]
+    title: Default theme is dark
+    verification: automated-test
+    description: |
+      GIVEN the TUI is launched without specifying a theme
+      WHEN no --theme flag or --css-file flag is provided
+      THEN the dark theme stylesheet is loaded from bundled resources
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.18.1
+    requirement_ids: ["TUI_0001.18"]
+    title: Light theme via --theme flag
+    verification: automated-test
+    description: |
+      GIVEN the TUI is launched with --theme light
+      WHEN the StyleEngine is initialized
+      THEN the light theme stylesheet is loaded from bundled resources
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.18.2
+    requirement_ids: ["TUI_0001.18"]
+    title: User CSS file via --css-file flag
+    verification: automated-test
+    description: |
+      GIVEN the TUI is launched with --css-file pointing to a valid TCSS file
+      WHEN the StyleEngine is initialized
+      THEN the user-provided CSS file is loaded and replaces the bundled theme
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.18.3
+    requirement_ids: ["TUI_0001.18"]
+    title: XDG config CSS auto-loaded
+    verification: automated-test
+    description: |
+      GIVEN ~/.config/atunko/theme.tcss exists and no --css-file flag is specified
+      WHEN the TUI is launched
+      THEN the XDG config CSS file is loaded and replaces the bundled theme
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.18.4
+    requirement_ids: ["TUI_0001.18"]
+    title: Theme flag selects bundled theme
+    verification: automated-test
+    description: |
+      GIVEN the TUI is launched with --theme dark or --theme light
+      WHEN the StyleEngine is initialized
+      THEN the corresponding bundled theme stylesheet is loaded
+    revision: "0.1.0"
+
   - id: SVC_CLI_0002
     requirement_ids: ["CLI_0002"]
     title: List recipes via CLI

--- a/openspec/changes/tui-css-theming/design.md
+++ b/openspec/changes/tui-css-theming/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The TUI uses TamboUI's Toolkit DSL (`ToolkitApp`, `Element`, `Dock`, `Column`, etc.) with all styling applied inline via `.fg(Color.X)`, `.bg(Color.Y)`, `.bold()`, `.borderColor(Color.Z)`. The `tamboui-css` dependency is already declared but unused. Elements already have IDs (`#browser`, `#detail`, `#tag-browser`, `#confirm-run`, `#execution-results`) but no CSS classes.
+
+TamboUI's CSS module (`tamboui-css`) provides a `StyleEngine` that loads TCSS stylesheets, resolves styles via type/ID/class/pseudo-class selectors, and integrates with `ToolkitRunner`. Elements with `.id()` and `.cssClass()` automatically participate in CSS styling.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extract all inline styles from views into TCSS stylesheets
+- Ship two bundled themes (dark, light) as classpath resources in the JAR
+- Default to dark theme when no theme is specified
+- Support `--theme dark|light` CLI flag on `tui` subcommand
+- Support `--css-file <path>` CLI flag for user-provided CSS
+- Auto-load `~/.config/atunko/theme.tcss` if present (lower priority than `--css-file`)
+- User CSS replaces the bundled theme (no layering)
+- Use semantic CSS classes across all views
+
+**Non-Goals:**
+- Auto-detecting terminal background color (unreliable across terminals)
+- Runtime theme switching within a TUI session (restart required)
+- Theming the Web UI (separate concern, Vaadin has its own theming)
+- Partial/layered CSS (user CSS on top of bundled theme)
+
+## Decisions
+
+### 1. StyleEngine initialized in AtunkoTui, configured via TuiConfig/ToolkitRunner
+
+**Decision**: Create and configure the `StyleEngine` in `AtunkoTui`'s constructor, passing it to the `ToolkitRunner` via the builder API.
+
+**Rationale**: `AtunkoTui` extends `ToolkitApp` and is the natural place to own the style engine lifecycle. The `ToolkitRunner` builder integrates with `StyleEngine` natively.
+
+### 2. Theme resolution order
+
+**Decision**: Resolve the active theme in this order:
+1. `--css-file <path>` → load that file as an inline stylesheet (replaces bundled)
+2. `~/.config/atunko/theme.tcss` exists → load it (replaces bundled)
+3. `--theme dark|light` → load the named bundled theme
+4. No flags → load `dark.tcss` (default)
+
+**Rationale**: User-provided CSS is the most explicit override. XDG config is a persistent preference. CLI flag is a session override. Default is dark (safe for most dev terminals).
+
+### 3. Bundled themes as classpath resources
+
+**Decision**: Ship themes at `themes/dark.tcss` and `themes/light.tcss` in `atunko-tui/src/main/resources/`. Load via `StyleEngine.loadStylesheet(name, classpathResource)`.
+
+**Rationale**: Classpath resources are packaged in the shadow JAR and accessible without filesystem paths. Named stylesheets integrate with `StyleEngine`'s theme switching API.
+
+### 4. Semantic CSS class vocabulary
+
+**Decision**: Use the following semantic classes across all views:
+
+| Class | Purpose |
+|-------|---------|
+| `.app` | Root element — overall background and default text color |
+| `.screen-title` | View title bars (e.g., "Recipe Browser", "Tag Browser") |
+| `.status-bar` | Footer help/status lines |
+| `.panel` | Bordered content panels |
+| `.list-item` | Individual items in lists |
+| `.section-header` | Section labels within views |
+| `.selected` | Selected state indicator |
+| `.search-mode` | Search/filter mode title styling |
+| `.recipe-name` | Recipe name text |
+| `.recipe-description` | Recipe description text |
+| `.tag` | Tag labels |
+| `.coverage-indicator` | Coverage status markers |
+
+**Rationale**: Semantic classes decouple visual style from view structure. Themes can restyle the entire app by targeting these classes without knowing view-specific layout. This is more maintainable than per-view selectors.
+
+### 5. Full inline style extraction (Option A)
+
+**Decision**: Remove ALL inline style calls (`.fg()`, `.bg()`, `.bold()`, `.borderColor()`, etc.) from view files. Views assign only structure (layout, content) and semantic classes. All visual styling comes from CSS.
+
+**Rationale**: Partial extraction (keeping some inline styles as "defaults") creates confusion about which styles come from where and makes themes unreliable. Full extraction ensures themes have complete control.
+
+### 6. Theme options passed from TuiCommand to AtunkoTui
+
+**Decision**: Add `--theme` and `--css-file` as Picocli `@Option` fields on `TuiCommand`. Pass them to `AtunkoTui` via constructor or a config record.
+
+**Rationale**: `TuiCommand` is the CLI entry point and already handles `--project-dir` and `--log-file`. Theme options are TUI-specific (not on the top-level `atunko` command).
+
+## Risks / Trade-offs
+
+- **Visual regression risk**: Extracting ~70+ inline styles and recreating them in TCSS is error-prone. A style missed in CSS will render with terminal defaults instead of the intended color. Mitigation: systematic extraction — map each view's inline styles to CSS rules, then visually verify.
+- **TamboUI CSS property coverage**: Not all inline style methods may have CSS equivalents (e.g., `Color.indexed(236)` — need to verify TCSS supports indexed/256 colors). Mitigation: check TamboUI CSS property support during implementation; fall back to hex equivalents if indexed colors aren't supported.
+- **User CSS learning curve**: Users need to know the semantic class names and supported TCSS properties to write custom themes. Mitigation: document the class vocabulary and ship well-commented bundled themes as examples.
+
+## Migration Plan
+
+Purely additive to `atunko-tui`. No changes to `atunko-core` or `atunko-cli`. No data migration. The visual appearance with the default dark theme should be identical to the current hardcoded styling.

--- a/openspec/changes/tui-css-theming/proposal.md
+++ b/openspec/changes/tui-css-theming/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The TUI currently hardcodes ~70+ color values inline across 6 view files (`BrowserView`, `DetailView`, `TagBrowserView`, `ConfirmRunView`, `ExecutionResultsView`, `HelpOverlay`). This makes visual consistency fragile, theming impossible, and customization a source-code change. TamboUI provides a CSS module (`tamboui-css`) with a `StyleEngine` that supports TCSS stylesheets, semantic selectors, and runtime theme switching — the dependency is already declared but unused.
+
+Adding CSS theming extracts all inline styles into TCSS files, ships two bundled themes (dark and light), and gives users the option to supply their own CSS file for full customization.
+
+## What Changes
+
+- All inline color/style values are removed from TUI view files
+- Elements gain semantic CSS classes (`.screen-title`, `.status-bar`, `.panel`, `.selected`, etc.)
+- A `StyleEngine` is initialized in `AtunkoTui` and loaded with the active theme
+- Two bundled TCSS themes ship in the JAR: `dark.tcss` (default) and `light.tcss`
+- `TuiCommand` gains `--theme dark|light` and `--css-file <path>` Picocli options
+- User CSS from `~/.config/atunko/theme.tcss` is auto-loaded if present (unless `--css-file` overrides)
+- User-provided CSS replaces the bundled theme entirely (no layering)
+
+## Capabilities
+
+### New Capabilities
+
+- `tui-css-theming`: CSS-based theming for the TUI — semantic style classes, bundled dark/light themes, user-provided CSS file support, theme selection via `--theme` flag
+
+### Modified Capabilities
+
+- `tui-launch`: The TUI bootstrap changes — `AtunkoTui` initializes a `StyleEngine` and passes it to the `ToolkitRunner`. Views no longer contain inline styles; all styling is resolved via CSS.
+
+## Impact
+
+- `atunko-tui`: All 6 view files (inline style removal + CSS class assignment), `AtunkoTui` (StyleEngine setup), `TuiCommand` (new CLI options), new TCSS resource files
+- `atunko-core`: No changes
+- `atunko-cli`: No changes
+- No breaking behavioral changes — the TUI looks the same (dark theme is the default), but styling is now externalized

--- a/openspec/changes/tui-css-theming/specs/tui-css-theming/spec.md
+++ b/openspec/changes/tui-css-theming/specs/tui-css-theming/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: TUI_0001.18
+The system SHALL implement TUI_0001.18.
+
+#### Scenario: SVC_TUI_0001.18
+The system SHALL pass SVC_TUI_0001.18.
+
+#### Scenario: SVC_TUI_0001.18.1
+The system SHALL pass SVC_TUI_0001.18.1.
+
+#### Scenario: SVC_TUI_0001.18.2
+The system SHALL pass SVC_TUI_0001.18.2.
+
+#### Scenario: SVC_TUI_0001.18.3
+The system SHALL pass SVC_TUI_0001.18.3.
+
+#### Scenario: SVC_TUI_0001.18.4
+The system SHALL pass SVC_TUI_0001.18.4.

--- a/openspec/changes/tui-css-theming/specs/tui-launch/spec.md
+++ b/openspec/changes/tui-css-theming/specs/tui-launch/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: TUI_0001.18
+The system SHALL implement TUI_0001.18.
+
+#### Scenario: SVC_TUI_0001.18
+The system SHALL pass SVC_TUI_0001.18.
+
+#### Scenario: SVC_TUI_0001.18.1
+The system SHALL pass SVC_TUI_0001.18.1.
+
+#### Scenario: SVC_TUI_0001.18.2
+The system SHALL pass SVC_TUI_0001.18.2.
+
+#### Scenario: SVC_TUI_0001.18.3
+The system SHALL pass SVC_TUI_0001.18.3.
+
+#### Scenario: SVC_TUI_0001.18.4
+The system SHALL pass SVC_TUI_0001.18.4.

--- a/openspec/changes/tui-css-theming/tasks.md
+++ b/openspec/changes/tui-css-theming/tasks.md
@@ -1,0 +1,47 @@
+## 1. reqstool — Requirements & SVCs
+
+- [x] 1.1 Add TUI_0001.18 (TUI — CSS Theming) to `docs/reqstool/requirements.yml` as a sub-requirement of TUI_0001
+- [x] 1.2 Add SVC_TUI_0001.18 (dark theme: TUI renders with dark theme styles from CSS when no theme is specified) to SVCs
+- [x] 1.3 Add SVC_TUI_0001.18.1 (light theme: TUI renders with light theme styles from CSS when `--theme light` is specified) to SVCs
+- [x] 1.4 Add SVC_TUI_0001.18.2 (user CSS file: TUI loads user-provided CSS file via `--css-file` flag, replacing bundled theme) to SVCs
+- [x] 1.5 Add SVC_TUI_0001.18.3 (XDG user CSS: TUI loads `~/.config/atunko/theme.tcss` when present and no `--css-file` is specified) to SVCs
+- [x] 1.6 Add SVC_TUI_0001.18.4 (theme flag: `--theme dark|light` selects bundled theme) to SVCs
+- [x] 1.7 Update `atunko-tui/docs/reqstool` filter to include TUI_0001.18 and all new SVC IDs
+
+## 2. Bundled TCSS Themes
+
+- [x] 2.1 Create `atunko-tui/src/main/resources/themes/dark.tcss` — extract all current inline styles into CSS rules using semantic classes
+- [x] 2.2 Create `atunko-tui/src/main/resources/themes/light.tcss` — light variant with inverted/appropriate colors
+
+## 3. View Refactoring — Inline Style Extraction
+
+- [x] 3.1 Add semantic `.cssClass()` calls to all elements in `BrowserView` and remove inline style calls
+- [x] 3.2 Add semantic `.cssClass()` calls to all elements in `DetailView` and remove inline style calls
+- [x] 3.3 Add semantic `.cssClass()` calls to all elements in `TagBrowserView` and remove inline style calls
+- [x] 3.4 Add semantic `.cssClass()` calls to all elements in `ConfirmRunView` and remove inline style calls
+- [x] 3.5 Add semantic `.cssClass()` calls to all elements in `ExecutionResultsView` and remove inline style calls
+- [x] 3.6 Add semantic `.cssClass()` calls to all elements in `HelpOverlay` and remove inline style calls
+- [x] 3.7 Add semantic `.cssClass()` calls to `RecipeListRenderer` and remove inline style calls
+
+## 4. StyleEngine Integration
+
+- [x] 4.1 Create `StyleEngine` in `AtunkoTui` constructor — load bundled theme or user CSS based on resolution order
+- [x] 4.2 Pass `StyleEngine` to `ToolkitRunner` via builder API
+- [x] 4.3 Add `--theme` and `--css-file` Picocli `@Option` fields to `TuiCommand`
+- [x] 4.4 Pass theme options from `TuiCommand` to `AtunkoTui` (constructor parameter or config record)
+
+## 5. Tests
+
+- [x] 5.1 Write unit test: default theme is dark when no flags specified, annotated `@SVCs({"atunko:SVC_TUI_0001.18"})`
+- [x] 5.2 Write unit test: `--theme light` selects light theme, annotated `@SVCs({"atunko:SVC_TUI_0001.18.1", "atunko:SVC_TUI_0001.18.4"})`
+- [x] 5.3 Write unit test: `--css-file` loads user CSS and replaces bundled theme, annotated `@SVCs({"atunko:SVC_TUI_0001.18.2"})`
+- [x] 5.4 Write unit test: XDG config file auto-loaded when present, annotated `@SVCs({"atunko:SVC_TUI_0001.18.3"})`
+- [x] 5.5 Write unit test: `--css-file` takes priority over XDG config file
+- [x] 5.6 Write unit test: user CSS replaces (not layers on) bundled theme
+
+## 6. Build & Verification
+
+- [x] 6.1 Run `./gradlew spotlessApply` to fix formatting
+- [x] 6.2 Run `./gradlew build` — all checks pass (Spotless, Checkstyle, Error Prone, tests)
+- [x] 6.3 Run `openspec validate --all --strict` to verify spec integrity
+- [ ] 6.4 Visual verification: run TUI with dark theme, light theme, and custom CSS file


### PR DESCRIPTION
## Summary
- Extract all inline styles from TUI views into semantic CSS classes, ship bundled dark/light TCSS themes
- Add `--theme dark|light` and `--css-file` CLI options on `tui` subcommand, with XDG config fallback (`~/.config/atunko/theme.tcss`)
- Add TUI_0001.18 requirement, 5 SVCs, and 8 unit tests for ThemeConfig resolution logic
- Fix openspec spec validation (missing/brief Purpose sections in 4 specs)

## Test plan
- [x] `./gradlew build` passes (111 tests green, Spotless/Checkstyle/Error Prone clean)
- [x] `openspec validate --all --strict` — 12/12 pass
- [ ] Visual verification: run TUI with `--theme dark`, `--theme light`, and `--css-file`

Closes #14