### PR TITLE
feat(web): add run order, save/load, sorting, bulk select, coverage, included-in (#36–#41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
           java-version: 25
           cache: gradle
 
-      - name: Install Playwright browsers
-        run: ./gradlew :atunko-web:compileIntegrationTestJava && npx playwright install --with-deps chromium
+      - name: Install Playwright Chromium
+        run: ./gradlew :atunko-web:playwrightInstall
 
       - name: Integration tests
         run: ./gradlew :atunko-web:integrationTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,22 @@ jobs:
 
       - name: Build
         run: ./gradlew build
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: gradle
+
+      - name: Install Playwright browsers
+        run: ./gradlew :atunko-web:compileIntegrationTestJava && npx playwright install --with-deps chromium
+
+      - name: Integration tests
+        run: ./gradlew :atunko-web:integrationTest

--- a/atunko-cli/src/test/java/io/github/atunkodev/AppTest.java
+++ b/atunko-cli/src/test/java/io/github/atunkodev/AppTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 class AppTest {
 
     @Test
-    void help_printsUsage() {
+    void helpPrintsUsage() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("--help");
@@ -21,7 +21,7 @@ class AppTest {
     }
 
     @Test
-    void noArgs_printsUsage() {
+    void noArgsPrintsUsage() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute();

--- a/atunko-cli/src/test/java/io/github/atunkodev/cli/ListCommandTest.java
+++ b/atunko-cli/src/test/java/io/github/atunkodev/cli/ListCommandTest.java
@@ -15,7 +15,7 @@ class ListCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0002.1"})
-    void list_displaysRecipesAsText() {
+    void listDisplaysRecipesAsText() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("list");
@@ -28,7 +28,7 @@ class ListCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0002.2"})
-    void list_displaysRecipesAsJson() throws Exception {
+    void listDisplaysRecipesAsJson() throws Exception {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("list", "--format", "json");
@@ -46,7 +46,7 @@ class ListCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0002.3"})
-    void list_sortsByNameByDefault() {
+    void listSortsByNameByDefault() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("list", "--sort", "name");
@@ -57,7 +57,7 @@ class ListCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0002.4"})
-    void list_sortsByTags() {
+    void listSortsByTags() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("list", "--sort", "tags");

--- a/atunko-cli/src/test/java/io/github/atunkodev/cli/RunCommandTest.java
+++ b/atunko-cli/src/test/java/io/github/atunkodev/cli/RunCommandTest.java
@@ -31,7 +31,7 @@ class RunCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0003"})
-    void run_withValidRecipe_reportsChanges() throws IOException {
+    void runWithValidRecipeReportsChanges() throws IOException {
         Path workDir = copyFixtureToTemp();
         CommandLineFixture cli = CommandLineFixture.create();
 
@@ -45,7 +45,7 @@ class RunCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0003"})
-    void run_withInvalidRecipe_reportsError() throws IOException {
+    void runWithInvalidRecipeReportsError() throws IOException {
         Path workDir = copyFixtureToTemp();
         CommandLineFixture cli = CommandLineFixture.create();
 
@@ -58,7 +58,7 @@ class RunCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0003"})
-    void run_withMissingRequiredOptions_fails() {
+    void runWithMissingRequiredOptionsFails() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("run");

--- a/atunko-cli/src/test/java/io/github/atunkodev/cli/SearchCommandTest.java
+++ b/atunko-cli/src/test/java/io/github/atunkodev/cli/SearchCommandTest.java
@@ -15,7 +15,7 @@ class SearchCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0004.1"})
-    void search_displaysMatchingRecipesAsText() {
+    void searchDisplaysMatchingRecipesAsText() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("search", "unused imports");
@@ -27,7 +27,7 @@ class SearchCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0004.1"})
-    void search_showsMessageWhenNoResults() {
+    void searchShowsMessageWhenNoResults() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("search", "xyznonexistent999");
@@ -38,7 +38,7 @@ class SearchCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0004.2"})
-    void search_displaysMatchingRecipesAsJson() throws Exception {
+    void searchDisplaysMatchingRecipesAsJson() throws Exception {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("search", "unused imports", "--format", "json");
@@ -55,7 +55,7 @@ class SearchCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0004.3"})
-    void search_sortsByName() {
+    void searchSortsByName() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("search", "java", "--sort", "name");
@@ -66,7 +66,7 @@ class SearchCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0004.4"})
-    void search_sortsByTags() {
+    void searchSortsByTags() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         int exitCode = cli.execute("search", "java", "--sort", "tags");
@@ -77,7 +77,7 @@ class SearchCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_CLI_0004.5"})
-    void search_filtersByField() {
+    void searchFiltersByField() {
         CommandLineFixture cli = CommandLineFixture.create();
 
         // Search only in tags — "java" is a common tag

--- a/atunko-core/src/main/java/io/github/atunkodev/core/config/RecipeEntry.java
+++ b/atunko-core/src/main/java/io/github/atunkodev/core/config/RecipeEntry.java
@@ -1,12 +1,10 @@
 package io.github.atunkodev.core.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record RecipeEntry(
         String name,

--- a/atunko-core/src/main/java/io/github/atunkodev/core/config/RecipeEntry.java
+++ b/atunko-core/src/main/java/io/github/atunkodev/core/config/RecipeEntry.java
@@ -1,0 +1,19 @@
+package io.github.atunkodev.core.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RecipeEntry(
+        String name,
+        @Nullable Map<String, Object> options,
+        @Nullable List<String> exclude) {
+
+    public RecipeEntry(String name) {
+        this(name, null, null);
+    }
+}

--- a/atunko-core/src/main/java/io/github/atunkodev/core/config/RunConfig.java
+++ b/atunko-core/src/main/java/io/github/atunkodev/core/config/RunConfig.java
@@ -1,14 +1,21 @@
 package io.github.atunkodev.core.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record RunConfig(int version, List<String> recipes) {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RunConfig(int version, @Nullable String description, List<RecipeEntry> recipes) {
 
     public static final int CURRENT_VERSION = 1;
 
-    public RunConfig(List<String> recipes) {
-        this(CURRENT_VERSION, recipes);
+    public RunConfig(List<RecipeEntry> recipes) {
+        this(CURRENT_VERSION, null, recipes);
+    }
+
+    public RunConfig(@Nullable String description, List<RecipeEntry> recipes) {
+        this(CURRENT_VERSION, description, recipes);
     }
 }

--- a/atunko-core/src/main/java/io/github/atunkodev/core/config/RunConfig.java
+++ b/atunko-core/src/main/java/io/github/atunkodev/core/config/RunConfig.java
@@ -1,11 +1,9 @@
 package io.github.atunkodev.core.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record RunConfig(int version, @Nullable String description, List<RecipeEntry> recipes) {
 

--- a/atunko-core/src/main/resources/run.schema.json
+++ b/atunko-core/src/main/resources/run.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://atunko.dev/schemas/run.schema.json",
+  "title": "atunko Run Configuration",
+  "description": "Schema for atunko run configuration files (atunko/runs/*.yaml)",
+  "type": "object",
+  "required": ["version", "recipes"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of this run configuration"
+    },
+    "recipes": {
+      "type": "array",
+      "description": "List of recipes to execute",
+      "items": {
+        "$ref": "#/$defs/recipeEntry"
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "recipeEntry": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Fully qualified OpenRewrite recipe name"
+        },
+        "options": {
+          "type": "object",
+          "description": "Recipe-specific options (key-value pairs)",
+          "additionalProperties": true
+        },
+        "exclude": {
+          "type": "array",
+          "description": "Sub-recipes to exclude from a composite recipe",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/atunko-core/src/test/java/io/github/atunkodev/core/AppServicesTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/AppServicesTest.java
@@ -19,7 +19,7 @@ class AppServicesTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.12"})
-    void init_storesEngine() {
+    void initStoresEngine() {
         RecipeExecutionEngine engine = new RecipeExecutionEngine(null);
         AppServices.init(engine, null, null);
         assertThat(AppServices.getEngine()).isSameAs(engine);
@@ -27,7 +27,7 @@ class AppServicesTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.12"})
-    void init_storesSourceParser() {
+    void initStoresSourceParser() {
         ProjectSourceParser parser = new ProjectSourceParser();
         AppServices.init(null, parser, null);
         assertThat(AppServices.getSourceParser()).isSameAs(parser);
@@ -35,7 +35,7 @@ class AppServicesTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.12"})
-    void init_storesChangeApplier() {
+    void initStoresChangeApplier() {
         ChangeApplier applier = new ChangeApplier();
         AppServices.init(null, null, applier);
         assertThat(AppServices.getChangeApplier()).isSameAs(applier);
@@ -43,7 +43,7 @@ class AppServicesTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.12"})
-    void init_multipleCallsOverwritesPreviousValues() {
+    void initMultipleCallsOverwritesPreviousValues() {
         RecipeExecutionEngine engine1 = new RecipeExecutionEngine(null);
         RecipeExecutionEngine engine2 = new RecipeExecutionEngine(null);
         AppServices.init(engine1, null, null);
@@ -53,7 +53,7 @@ class AppServicesTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.12"})
-    void beforeInit_allGettersReturnNull() {
+    void beforeInitAllGettersReturnNull() {
         assertThat(AppServices.getEngine()).isNull();
         assertThat(AppServices.getSourceParser()).isNull();
         assertThat(AppServices.getChangeApplier()).isNull();

--- a/atunko-core/src/test/java/io/github/atunkodev/core/config/RunConfigServiceTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/config/RunConfigServiceTest.java
@@ -21,7 +21,7 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0007"})
-    void save_writesYamlFile() throws IOException {
+    void saveWritesYamlFile() throws IOException {
         RunConfig config = new RunConfig(List.of(
                 new RecipeEntry("org.openrewrite.java.cleanup.RemoveUnusedImports"),
                 new RecipeEntry("org.openrewrite.java.format.AutoFormat")));
@@ -39,7 +39,7 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0007"})
-    void save_withDescription_includesDescription() throws IOException {
+    void saveWithDescriptionIncludesDescription() throws IOException {
         RunConfig config =
                 new RunConfig("Spring Boot migration", List.of(new RecipeEntry("org.openrewrite.java.Boot")));
 
@@ -53,7 +53,7 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0007"})
-    void save_withOptionsAndExclude_writesStructuredEntry() throws IOException {
+    void saveWithOptionsAndExcludeWritesStructuredEntry() throws IOException {
         RecipeEntry entry = new RecipeEntry(
                 "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_5",
                 Map.of("newVersion", "3.5.0"),
@@ -72,7 +72,7 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0007"})
-    void save_withEmptyRecipes_writesEmptyList() throws IOException {
+    void saveWithEmptyRecipesWritesEmptyList() throws IOException {
         RunConfig config = new RunConfig(List.of());
 
         Path file = tempDir.resolve("run.yaml");
@@ -85,7 +85,7 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0007"})
-    void save_overwritesExistingFile() throws IOException {
+    void saveOverwritesExistingFile() throws IOException {
         Path file = tempDir.resolve("run.yaml");
         Files.writeString(file, "old content");
 
@@ -99,7 +99,7 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0008"})
-    void load_readsYamlFile() throws IOException {
+    void loadReadsYamlFile() throws IOException {
         RunConfig original = new RunConfig(
                 "Test config",
                 List.of(
@@ -120,7 +120,7 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0008"})
-    void load_withOptionsAndExclude_roundTrips() throws IOException {
+    void loadWithOptionsAndExcludeRoundTrips() throws IOException {
         RecipeEntry entry = new RecipeEntry(
                 "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_5",
                 Map.of("newVersion", "3.5.0"),
@@ -141,13 +141,13 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0008"})
-    void load_nonExistentFile_throws() {
+    void loadNonExistentFileThrows() {
         assertThatThrownBy(() -> service.load(Path.of("/nonexistent/run.yaml"))).isInstanceOf(IOException.class);
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0008"})
-    void load_invalidYaml_throws() throws IOException {
+    void loadInvalidYamlThrows() throws IOException {
         Path file = tempDir.resolve("run.yaml");
         Files.writeString(file, "not: [valid: yaml: for: runconfig");
 
@@ -156,7 +156,7 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0008"})
-    void load_minimalYaml_works() throws IOException {
+    void loadMinimalYamlWorks() throws IOException {
         Path file = tempDir.resolve("run.yaml");
         Files.writeString(file, "version: 1\nrecipes:\n- name: org.openrewrite.java.RemoveUnusedImports\n");
 

--- a/atunko-core/src/test/java/io/github/atunkodev/core/config/RunConfigServiceTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/config/RunConfigServiceTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -21,10 +22,11 @@ class RunConfigServiceTest {
     @Test
     @SVCs({"atunko:SVC_CORE_0007"})
     void save_writesYamlFile() throws IOException {
-        RunConfig config = new RunConfig(
-                List.of("org.openrewrite.java.cleanup.RemoveUnusedImports", "org.openrewrite.java.format.AutoFormat"));
+        RunConfig config = new RunConfig(List.of(
+                new RecipeEntry("org.openrewrite.java.cleanup.RemoveUnusedImports"),
+                new RecipeEntry("org.openrewrite.java.format.AutoFormat")));
 
-        Path file = tempDir.resolve(".atunko.yml");
+        Path file = tempDir.resolve("run.yaml");
         service.save(config, file);
 
         assertThat(file).exists();
@@ -37,10 +39,43 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0007"})
+    void save_withDescription_includesDescription() throws IOException {
+        RunConfig config =
+                new RunConfig("Spring Boot migration", List.of(new RecipeEntry("org.openrewrite.java.Boot")));
+
+        Path file = tempDir.resolve("run.yaml");
+        service.save(config, file);
+
+        String content = Files.readString(file);
+        assertThat(content).contains("description:");
+        assertThat(content).contains("Spring Boot migration");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0007"})
+    void save_withOptionsAndExclude_writesStructuredEntry() throws IOException {
+        RecipeEntry entry = new RecipeEntry(
+                "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_5",
+                Map.of("newVersion", "3.5.0"),
+                List.of("org.openrewrite.java.spring.boot3.SomeSubRecipe"));
+        RunConfig config = new RunConfig("With options", List.of(entry));
+
+        Path file = tempDir.resolve("run.yaml");
+        service.save(config, file);
+
+        String content = Files.readString(file);
+        assertThat(content).contains("newVersion:");
+        assertThat(content).contains("3.5.0");
+        assertThat(content).contains("exclude:");
+        assertThat(content).contains("org.openrewrite.java.spring.boot3.SomeSubRecipe");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0007"})
     void save_withEmptyRecipes_writesEmptyList() throws IOException {
         RunConfig config = new RunConfig(List.of());
 
-        Path file = tempDir.resolve(".atunko.yml");
+        Path file = tempDir.resolve("run.yaml");
         service.save(config, file);
 
         assertThat(file).exists();
@@ -51,10 +86,10 @@ class RunConfigServiceTest {
     @Test
     @SVCs({"atunko:SVC_CORE_0007"})
     void save_overwritesExistingFile() throws IOException {
-        Path file = tempDir.resolve(".atunko.yml");
+        Path file = tempDir.resolve("run.yaml");
         Files.writeString(file, "old content");
 
-        RunConfig config = new RunConfig(List.of("org.openrewrite.java.cleanup.RemoveUnusedImports"));
+        RunConfig config = new RunConfig(List.of(new RecipeEntry("org.openrewrite.java.cleanup.RemoveUnusedImports")));
         service.save(config, file);
 
         String content = Files.readString(file);
@@ -66,28 +101,54 @@ class RunConfigServiceTest {
     @SVCs({"atunko:SVC_CORE_0008"})
     void load_readsYamlFile() throws IOException {
         RunConfig original = new RunConfig(
-                List.of("org.openrewrite.java.cleanup.RemoveUnusedImports", "org.openrewrite.java.format.AutoFormat"));
+                "Test config",
+                List.of(
+                        new RecipeEntry("org.openrewrite.java.cleanup.RemoveUnusedImports"),
+                        new RecipeEntry("org.openrewrite.java.format.AutoFormat")));
 
-        Path file = tempDir.resolve(".atunko.yml");
+        Path file = tempDir.resolve("run.yaml");
         service.save(original, file);
 
         RunConfig loaded = service.load(file);
 
-        assertThat(loaded.recipes()).containsExactlyElementsOf(original.recipes());
+        assertThat(loaded.recipes()).hasSize(2);
+        assertThat(loaded.recipes().get(0).name()).isEqualTo("org.openrewrite.java.cleanup.RemoveUnusedImports");
+        assertThat(loaded.recipes().get(1).name()).isEqualTo("org.openrewrite.java.format.AutoFormat");
+        assertThat(loaded.description()).isEqualTo("Test config");
         assertThat(loaded.version()).isEqualTo(RunConfig.CURRENT_VERSION);
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0008"})
+    void load_withOptionsAndExclude_roundTrips() throws IOException {
+        RecipeEntry entry = new RecipeEntry(
+                "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_5",
+                Map.of("newVersion", "3.5.0"),
+                List.of("org.openrewrite.java.spring.boot3.SomeSubRecipe"));
+        RunConfig original = new RunConfig(List.of(entry));
+
+        Path file = tempDir.resolve("run.yaml");
+        service.save(original, file);
+
+        RunConfig loaded = service.load(file);
+
+        assertThat(loaded.recipes()).hasSize(1);
+        RecipeEntry loadedEntry = loaded.recipes().get(0);
+        assertThat(loadedEntry.name()).isEqualTo("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_5");
+        assertThat(loadedEntry.options()).containsEntry("newVersion", "3.5.0");
+        assertThat(loadedEntry.exclude()).containsExactly("org.openrewrite.java.spring.boot3.SomeSubRecipe");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0008"})
     void load_nonExistentFile_throws() {
-        assertThatThrownBy(() -> service.load(Path.of("/nonexistent/.atunko.yml")))
-                .isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> service.load(Path.of("/nonexistent/run.yaml"))).isInstanceOf(IOException.class);
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0008"})
     void load_invalidYaml_throws() throws IOException {
-        Path file = tempDir.resolve(".atunko.yml");
+        Path file = tempDir.resolve("run.yaml");
         Files.writeString(file, "not: [valid: yaml: for: runconfig");
 
         assertThatThrownBy(() -> service.load(file)).isInstanceOf(Exception.class);
@@ -95,23 +156,16 @@ class RunConfigServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0008"})
-    void load_yamlWithNullRecipes_throws() throws IOException {
-        Path file = tempDir.resolve(".atunko.yml");
-        Files.writeString(file, "version: 1\nrecipes:\n");
-
-        // Jackson cannot deserialize bare "recipes:" (null) into a List — callers must provide a list
-        assertThatThrownBy(() -> service.load(file)).isInstanceOf(Exception.class);
-    }
-
-    @Test
-    @SVCs({"atunko:SVC_CORE_0008"})
-    void load_yamlWithoutVersion_usesDefaults() throws IOException {
-        Path file = tempDir.resolve(".atunko.yml");
-        Files.writeString(file, "recipes:\n- org.openrewrite.java.RemoveUnusedImports\n");
+    void load_minimalYaml_works() throws IOException {
+        Path file = tempDir.resolve("run.yaml");
+        Files.writeString(file, "version: 1\nrecipes:\n- name: org.openrewrite.java.RemoveUnusedImports\n");
 
         RunConfig loaded = service.load(file);
 
         assertThat(loaded).isNotNull();
-        assertThat(loaded.recipes()).containsExactly("org.openrewrite.java.RemoveUnusedImports");
+        assertThat(loaded.recipes()).hasSize(1);
+        assertThat(loaded.recipes().get(0).name()).isEqualTo("org.openrewrite.java.RemoveUnusedImports");
+        assertThat(loaded.recipes().get(0).options()).isNull();
+        assertThat(loaded.recipes().get(0).exclude()).isNull();
     }
 }

--- a/atunko-core/src/test/java/io/github/atunkodev/core/engine/RecipeExecutionEngineTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/engine/RecipeExecutionEngineTest.java
@@ -25,7 +25,7 @@ class RecipeExecutionEngineTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003"})
-    void execute_removesUnusedImports() {
+    void executeRemovesUnusedImports() {
         List<SourceFile> sources = parseFixture();
 
         ExecutionResult result = engine.execute("org.openrewrite.java.RemoveUnusedImports", sources);
@@ -41,7 +41,7 @@ class RecipeExecutionEngineTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003"})
-    void execute_withUnknownRecipe_throwsException() {
+    void executeWithUnknownRecipeThrowsException() {
         List<SourceFile> sources = parseFixture();
 
         assertThatThrownBy(() -> engine.execute("org.openrewrite.NonExistentRecipe", sources))
@@ -50,7 +50,7 @@ class RecipeExecutionEngineTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003"})
-    void execute_withNoMatchingChanges_returnsEmptyResult() {
+    void executeWithNoMatchingChangesReturnsEmptyResult() {
         List<SourceFile> sources = JavaParser.fromJavaVersion()
                 .build()
                 .parse(new InMemoryExecutionContext(), "package com.example;\n\npublic class Clean {\n}\n")

--- a/atunko-core/src/test/java/io/github/atunkodev/core/project/GradleProjectScannerTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/project/GradleProjectScannerTest.java
@@ -16,7 +16,7 @@ class GradleProjectScannerTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_GRADLE_0001"})
-    void scan_returnsNonEmptyClasspath() {
+    void scanReturnsNonEmptyClasspath() {
         ProjectInfo info = scanner.scan(ROOT_PROJECT_DIR);
 
         assertThat(info.classpath()).isNotEmpty();
@@ -25,7 +25,7 @@ class GradleProjectScannerTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_GRADLE_0001"})
-    void scan_returnsSourceDirectories() {
+    void scanReturnsSourceDirectories() {
         ProjectInfo info = scanner.scan(ROOT_PROJECT_DIR);
 
         assertThat(info.sourceDirs()).isNotEmpty();
@@ -34,7 +34,7 @@ class GradleProjectScannerTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_GRADLE_0001"})
-    void scan_nonExistentDirectory_throws() {
+    void scanNonExistentDirectoryThrows() {
         assertThatThrownBy(() -> scanner.scan(Path.of("/nonexistent/gradle/project")))
                 .isInstanceOf(Exception.class);
     }

--- a/atunko-core/src/test/java/io/github/atunkodev/core/project/MavenProjectScannerTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/project/MavenProjectScannerTest.java
@@ -15,7 +15,7 @@ class MavenProjectScannerTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_MAVEN_0001"})
-    void scan_returnsNonEmptyClasspath() {
+    void scanReturnsNonEmptyClasspath() {
         ProjectInfo info = scanner.scan(MAVEN_PROJECT_DIR);
 
         assertThat(info.classpath()).isNotEmpty();
@@ -24,7 +24,7 @@ class MavenProjectScannerTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_MAVEN_0001"})
-    void scan_returnsSourceDirectories() {
+    void scanReturnsSourceDirectories() {
         ProjectInfo info = scanner.scan(MAVEN_PROJECT_DIR);
 
         assertThat(info.sourceDirs()).isNotEmpty();
@@ -33,7 +33,7 @@ class MavenProjectScannerTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_MAVEN_0001"})
-    void scan_nonExistentDirectory_throws() {
+    void scanNonExistentDirectoryThrows() {
         assertThatThrownBy(() -> scanner.scan(Path.of("/nonexistent/maven/project")))
                 .isInstanceOf(Exception.class);
     }

--- a/atunko-core/src/test/java/io/github/atunkodev/core/project/ProjectScannerFactoryTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/project/ProjectScannerFactoryTest.java
@@ -15,35 +15,35 @@ class ProjectScannerFactoryTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.1"})
-    void detect_settingsGradle_returnsGradleScanner(@TempDir Path dir) throws IOException {
+    void detectSettingsGradleReturnsGradleScanner(@TempDir Path dir) throws IOException {
         Files.createFile(dir.resolve("settings.gradle"));
         assertThat(ProjectScannerFactory.detect(dir)).isInstanceOf(GradleProjectScanner.class);
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.1"})
-    void detect_buildGradleKts_returnsGradleScanner(@TempDir Path dir) throws IOException {
+    void detectBuildGradleKtsReturnsGradleScanner(@TempDir Path dir) throws IOException {
         Files.createFile(dir.resolve("build.gradle.kts"));
         assertThat(ProjectScannerFactory.detect(dir)).isInstanceOf(GradleProjectScanner.class);
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.1"})
-    void detect_settingsGradleKts_returnsGradleScanner(@TempDir Path dir) throws IOException {
+    void detectSettingsGradleKtsReturnsGradleScanner(@TempDir Path dir) throws IOException {
         Files.createFile(dir.resolve("settings.gradle.kts"));
         assertThat(ProjectScannerFactory.detect(dir)).isInstanceOf(GradleProjectScanner.class);
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.2"})
-    void detect_pomXml_returnsMavenScanner(@TempDir Path dir) throws IOException {
+    void detectPomXmlReturnsMavenScanner(@TempDir Path dir) throws IOException {
         Files.createFile(dir.resolve("pom.xml"));
         assertThat(ProjectScannerFactory.detect(dir)).isInstanceOf(MavenProjectScanner.class);
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.3"})
-    void detect_noBuildFiles_throwsIllegalArgument(@TempDir Path dir) {
+    void detectNoBuildFilesThrowsIllegalArgument(@TempDir Path dir) {
         assertThatThrownBy(() -> ProjectScannerFactory.detect(dir))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("No build files found");

--- a/atunko-core/src/test/java/io/github/atunkodev/core/project/ProjectSourceParserTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/project/ProjectSourceParserTest.java
@@ -16,7 +16,7 @@ class ProjectSourceParserTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003.1"})
-    void parse_parsesJavaFiles() {
+    void parseParsesJavaFiles() {
         ProjectInfo info = new ProjectInfo(
                 List.of(), List.of(FIXTURE_DIR.resolve("src/main/java")), List.of(), List.of(), List.of());
 
@@ -28,7 +28,7 @@ class ProjectSourceParserTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003.1"})
-    void parse_parsesYamlFiles() {
+    void parseParsesYamlFiles() {
         ProjectInfo info = new ProjectInfo(
                 List.of(), List.of(), List.of(FIXTURE_DIR.resolve("src/main/resources")), List.of(), List.of());
 
@@ -39,7 +39,7 @@ class ProjectSourceParserTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003.1"})
-    void parse_parsesPropertiesFiles() {
+    void parseParsesPropertiesFiles() {
         ProjectInfo info = new ProjectInfo(
                 List.of(), List.of(), List.of(FIXTURE_DIR.resolve("src/main/resources")), List.of(), List.of());
 
@@ -50,7 +50,7 @@ class ProjectSourceParserTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003.1"})
-    void parse_parsesXmlFiles() {
+    void parseParsesXmlFiles() {
         ProjectInfo info = new ProjectInfo(
                 List.of(), List.of(), List.of(FIXTURE_DIR.resolve("src/main/resources")), List.of(), List.of());
 
@@ -61,7 +61,7 @@ class ProjectSourceParserTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003.1"})
-    void parse_parsesJsonFiles() {
+    void parseParsesJsonFiles() {
         ProjectInfo info = new ProjectInfo(
                 List.of(), List.of(), List.of(FIXTURE_DIR.resolve("src/main/resources")), List.of(), List.of());
 
@@ -72,7 +72,7 @@ class ProjectSourceParserTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003.1"})
-    void parse_parsesAllFileTypesFromMultipleDirectories() {
+    void parseParsesAllFileTypesFromMultipleDirectories() {
         ProjectInfo info = new ProjectInfo(
                 List.of(),
                 List.of(FIXTURE_DIR.resolve("src/main/java")),
@@ -92,7 +92,7 @@ class ProjectSourceParserTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0003.1"})
-    void parse_emptyDirectories_returnsEmptyList() {
+    void parseEmptyDirectoriesReturnsEmptyList() {
         ProjectInfo info = new ProjectInfo(List.of(), List.of(), List.of(), List.of(), List.of());
 
         List<SourceFile> sources = parser.parse(info);

--- a/atunko-core/src/test/java/io/github/atunkodev/core/project/SessionHolderTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/project/SessionHolderTest.java
@@ -18,19 +18,19 @@ class SessionHolderTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.4"})
-    void getProjectDir_defaultsToCurrentDir() {
+    void getProjectDirDefaultsToCurrentDir() {
         assertThat(SessionHolder.getProjectDir()).isEqualTo(Path.of("."));
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.4"})
-    void getProjectInfo_defaultsToNull() {
+    void getProjectInfoDefaultsToNull() {
         assertThat(SessionHolder.getProjectInfo()).isNull();
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.4"})
-    void init_storesProjectDir() {
+    void initStoresProjectDir() {
         Path dir = Path.of("/some/project");
         SessionHolder.init(dir, null);
         assertThat(SessionHolder.getProjectDir()).isEqualTo(dir);
@@ -38,7 +38,7 @@ class SessionHolderTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.4"})
-    void init_storesProjectInfo() {
+    void initStoresProjectInfo() {
         Path dir = Path.of("/some/project");
         ProjectInfo info = new ProjectInfo(List.of(), List.of(dir));
         SessionHolder.init(dir, info);
@@ -47,7 +47,7 @@ class SessionHolderTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0004.4"})
-    void init_canBeCalledMultipleTimes_updatesState() {
+    void initCanBeCalledMultipleTimesUpdatesState() {
         SessionHolder.init(Path.of("/first"), null);
         Path second = Path.of("/second");
         SessionHolder.init(second, null);

--- a/atunko-core/src/test/java/io/github/atunkodev/core/recipe/EnvironmentProviderTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/recipe/EnvironmentProviderTest.java
@@ -8,7 +8,7 @@ import org.openrewrite.config.Environment;
 class EnvironmentProviderTest {
 
     @Test
-    void get_returnsSameInstanceOnSubsequentCalls() {
+    void getReturnsSameInstanceOnSubsequentCalls() {
         EnvironmentProvider provider = new EnvironmentProvider();
 
         Environment first = provider.get();
@@ -18,7 +18,7 @@ class EnvironmentProviderTest {
     }
 
     @Test
-    void invalidate_causesRebuildOnNextGet() {
+    void invalidateCausesRebuildOnNextGet() {
         EnvironmentProvider provider = new EnvironmentProvider();
 
         Environment first = provider.get();

--- a/atunko-core/src/test/java/io/github/atunkodev/core/recipe/RecipeDiscoveryServiceTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/recipe/RecipeDiscoveryServiceTest.java
@@ -13,14 +13,14 @@ class RecipeDiscoveryServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0001"})
-    void discoverAll_returnsNonEmptyList() {
+    void discoverAllReturnsNonEmptyList() {
         List<RecipeInfo> recipes = service.discoverAll();
         assertThat(recipes).isNotEmpty();
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0001"})
-    void discoverAll_recipesHaveNameAndDescription() {
+    void discoverAllRecipesHaveNameAndDescription() {
         List<RecipeInfo> recipes = service.discoverAll();
         assertThat(recipes).allSatisfy(recipe -> {
             assertThat(recipe.name()).isNotBlank();
@@ -30,14 +30,14 @@ class RecipeDiscoveryServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0001"})
-    void discoverAll_includesKnownRecipe() {
+    void discoverAllIncludesKnownRecipe() {
         List<RecipeInfo> recipes = service.discoverAll();
         assertThat(recipes).extracting(RecipeInfo::name).contains("org.openrewrite.java.RemoveUnusedImports");
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0002"})
-    void search_withMatchingKeyword_returnsFilteredRecipes() {
+    void searchWithMatchingKeywordReturnsFilteredRecipes() {
         List<RecipeInfo> results = service.search("RemoveUnusedImports");
         assertThat(results).isNotEmpty();
         assertThat(results)
@@ -47,7 +47,7 @@ class RecipeDiscoveryServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0002"})
-    void search_isCaseInsensitive() {
+    void searchIsCaseInsensitive() {
         List<RecipeInfo> upper = service.search("REMOVEUNUSEDIMPORTS");
         List<RecipeInfo> lower = service.search("removeunusedimports");
         List<RecipeInfo> mixed = service.search("RemoveUnusedImports");
@@ -58,7 +58,7 @@ class RecipeDiscoveryServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0002"})
-    void search_matchesAgainstNameDisplayNameDescriptionAndTags() {
+    void searchMatchesAgainstNameDisplayNameDescriptionAndTags() {
         // Match against name (fully qualified recipe name)
         assertThat(service.search("org.openrewrite.java.RemoveUnusedImports")).isNotEmpty();
 
@@ -78,14 +78,14 @@ class RecipeDiscoveryServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0002"})
-    void search_withNonMatchingKeyword_returnsEmptyList() {
+    void searchWithNonMatchingKeywordReturnsEmptyList() {
         List<RecipeInfo> results = service.search("zzz_no_recipe_matches_this_xyzzy");
         assertThat(results).isEmpty();
     }
 
     @Test
     @SVCs({"atunko:SVC_CORE_0002"})
-    void search_withBlankOrNullQuery_returnsAllRecipes() {
+    void searchWithBlankOrNullQueryReturnsAllRecipes() {
         List<RecipeInfo> all = service.discoverAll();
         assertThat(service.search(null)).isEqualTo(all);
         assertThat(service.search("")).isEqualTo(all);
@@ -94,7 +94,7 @@ class RecipeDiscoveryServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0001.1"})
-    void discoverAll_compositeRecipesExposeSubRecipes() {
+    void discoverAllCompositeRecipesExposeSubRecipes() {
         List<RecipeInfo> recipes = service.discoverAll();
 
         List<RecipeInfo> composites =
@@ -109,7 +109,7 @@ class RecipeDiscoveryServiceTest {
 
     @Test
     @SVCs({"atunko:SVC_CORE_0001.1"})
-    void discoverAll_nonCompositeRecipesHaveEmptyRecipeList() {
+    void discoverAllNonCompositeRecipesHaveEmptyRecipeList() {
         List<RecipeInfo> recipes = service.discoverAll();
 
         List<RecipeInfo> nonComposites =

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -1,5 +1,6 @@
 package io.github.atunkodev.tui;
 
+import io.github.atunkodev.core.config.RecipeEntry;
 import io.github.atunkodev.core.config.RunConfig;
 import io.github.atunkodev.core.config.RunConfigService;
 import io.github.atunkodev.core.engine.ChangeApplier;
@@ -781,7 +782,9 @@ public class TuiController {
 
     @Requirements({"atunko:TUI_0001.10"})
     public void saveRunConfig(Path file) throws IOException {
-        RunConfig config = new RunConfig(List.copyOf(selectedRecipes));
+        List<RecipeEntry> entries =
+                selectedRecipes.stream().map(RecipeEntry::new).toList();
+        RunConfig config = new RunConfig(entries);
         runConfigService.save(config, file);
     }
 

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/AtunkoTuiTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/AtunkoTuiTest.java
@@ -19,7 +19,7 @@ class AtunkoTuiTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.15"})
-    void logFile_configuresFileHandler(@TempDir Path tempDir) {
+    void logFileConfiguresFileHandler(@TempDir Path tempDir) {
         Path logFile = tempDir.resolve("debug.log");
         TuiController controller = new TuiController(RECIPES);
 

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -45,7 +45,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001"})
-    void initialState_browserScreenWithRecipesLoaded() {
+    void initialStateBrowserScreenWithRecipesLoaded() {
         TuiController controller = new TuiController(RECIPES);
 
         assertThat(controller.currentScreen()).isEqualTo(Screen.BROWSER);
@@ -57,7 +57,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.1"})
-    void recipes_exposesFilteredSortedList() {
+    void recipesExposesFilteredSortedList() {
         TuiController controller = new TuiController(RECIPES);
 
         List<RecipeInfo> visible = controller.recipes();
@@ -72,7 +72,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.3"})
-    void enterSearchMode_enablesSearchMode() {
+    void enterSearchModeEnablesSearchMode() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.enterSearchMode();
@@ -82,7 +82,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.3"})
-    void exitSearchMode_disablesSearchMode() {
+    void exitSearchModeDisablesSearchMode() {
         TuiController controller = new TuiController(RECIPES);
         controller.enterSearchMode();
 
@@ -95,7 +95,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.3"})
-    void setSearchQuery_filtersRecipesByNameDescriptionAndTags() {
+    void setSearchQueryFiltersRecipesByNameDescriptionAndTags() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.setSearchQuery("spring");
@@ -106,7 +106,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.3"})
-    void setSearchQuery_matchesByDescription() {
+    void setSearchQueryMatchesByDescription() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.setSearchQuery("Third");
@@ -116,7 +116,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.3"})
-    void setSearchQuery_emptyQueryShowsAll() {
+    void setSearchQueryEmptyQueryShowsAll() {
         TuiController controller = new TuiController(RECIPES);
         controller.setSearchQuery("spring");
 
@@ -127,7 +127,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.3"})
-    void setSearchQuery_resetsHighlightedIndex() {
+    void setSearchQueryResetsHighlightedIndex() {
         TuiController controller = new TuiController(RECIPES);
         controller.moveDown();
         controller.moveDown();
@@ -139,7 +139,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.6"})
-    void setSortOrder_reordersRecipeList() {
+    void setSortOrderReordersRecipeList() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.setSortOrder(SortOrder.TAGS);
@@ -155,7 +155,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.6"})
-    void setSortOrder_nameOrderIsAlphabetical() {
+    void setSortOrderNameOrderIsAlphabetical() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.setSortOrder(SortOrder.NAME);
@@ -170,7 +170,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.2"})
-    void highlightedRecipe_returnsCurrentlyHighlightedRecipe() {
+    void highlightedRecipeReturnsCurrentlyHighlightedRecipe() {
         TuiController controller = new TuiController(RECIPES);
 
         assertThat(controller.highlightedRecipe()).isPresent();
@@ -182,7 +182,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void toggleSelection_addsAndRemovesRecipes() {
+    void toggleSelectionAddsAndRemovesRecipes() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.toggleSelection();
@@ -199,7 +199,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.4"})
-    void openDetail_switchesToDetailScreen() {
+    void openDetailSwitchesToDetailScreen() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.openDetail();
@@ -209,7 +209,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.4"})
-    void goBack_returnsFromDetailToBrowser() {
+    void goBackReturnsFromDetailToBrowser() {
         TuiController controller = new TuiController(RECIPES);
         controller.openDetail();
 
@@ -220,7 +220,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.12"})
-    void moveDown_wrapsAtEnd() {
+    void moveDownWrapsAtEnd() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.moveDown();
@@ -233,7 +233,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.12"})
-    void moveUp_wrapsAtStart() {
+    void moveUpWrapsAtStart() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.moveUp();
@@ -245,7 +245,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.11"})
-    void allTags_returnsUniqueTagsSorted() {
+    void allTagsReturnsUniqueTagsSorted() {
         TuiController controller = new TuiController(RECIPES);
 
         List<String> tags = controller.allTags();
@@ -255,7 +255,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.11"})
-    void openTagBrowser_switchesToTagBrowserScreen() {
+    void openTagBrowserSwitchesToTagBrowserScreen() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.openTagBrowser();
@@ -265,7 +265,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.11"})
-    void toggleTag_andApply_filtersRecipesBySelectedTags() {
+    void toggleTagAndApplyFiltersRecipesBySelectedTags() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.toggleTag("spring");
@@ -277,7 +277,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.11"})
-    void toggleTag_multipleTagsFiltersUnion() {
+    void toggleTagMultipleTagsFiltersUnion() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.toggleTag("spring");
@@ -289,7 +289,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.11"})
-    void toggleTag_deselectsWhenAlreadySelected() {
+    void toggleTagDeselectsWhenAlreadySelected() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleTag("spring");
 
@@ -301,7 +301,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.11"})
-    void clearTagFilter_showsAllRecipes() {
+    void clearTagFilterShowsAllRecipes() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleTag("spring");
 
@@ -315,7 +315,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.7"})
-    void highlightedRecipe_isAvailableForOptionsLookup() {
+    void highlightedRecipeIsAvailableForOptionsLookup() {
         TuiController controller = new TuiController(RECIPES);
 
         assertThat(controller.highlightedRecipe()).isPresent();
@@ -326,7 +326,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.8"})
-    void showDryRunResult_storesResultAndSwitchesToExecutionScreen() {
+    void showDryRunResultStoresResultAndSwitchesToExecutionScreen() {
         TuiController controller = new TuiController(RECIPES);
         ExecutionResult result = new ExecutionResult(List.of(new FileChange(Path.of("Foo.java"), "before", "after")));
 
@@ -340,7 +340,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.9"})
-    void showExecutionResult_storesResultAndSwitchesToExecutionScreen() {
+    void showExecutionResultStoresResultAndSwitchesToExecutionScreen() {
         TuiController controller = new TuiController(RECIPES);
         ExecutionResult result = new ExecutionResult(List.of(new FileChange(Path.of("Foo.java"), "before", "after")));
 
@@ -355,7 +355,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.10"})
-    void saveRunConfig_persistsSelectedRecipes(@TempDir Path tempDir) throws Exception {
+    void saveRunConfigPersistsSelectedRecipes(@TempDir Path tempDir) throws Exception {
         RunConfigService service = new RunConfigService();
         TuiController controller = new TuiController(RECIPES, service);
         controller.toggleSelection(); // select Alpha
@@ -374,7 +374,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void cycleSelection_selectsAllWhenNoneSelected() {
+    void cycleSelectionSelectsAllWhenNoneSelected() {
         TuiController controller = new TuiController(RECIPES);
 
         controller.cycleSelection();
@@ -385,7 +385,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void cycleSelection_clearsWhenAllSelected() {
+    void cycleSelectionClearsWhenAllSelected() {
         TuiController controller = new TuiController(RECIPES);
         controller.cycleSelection(); // select all
 
@@ -396,7 +396,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void cycleSelection_selectsAllWhenPartiallySelected() {
+    void cycleSelectionSelectsAllWhenPartiallySelected() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection(); // select Alpha only
 
@@ -410,7 +410,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void expandRecipe_addsToExpandedSet() {
+    void expandRecipeAddsToExpandedSet() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
 
         controller.expandRecipe("org.test.Composite");
@@ -421,7 +421,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void collapseRecipe_removesFromExpandedSet() {
+    void collapseRecipeRemovesFromExpandedSet() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
 
@@ -432,7 +432,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void findRecipe_returnsCompositeWithSubRecipes() {
+    void findRecipeReturnsCompositeWithSubRecipes() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
 
         assertThat(controller.findRecipe("org.test.Composite")).isPresent();
@@ -446,7 +446,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void openConfirmRun_initializesRunOrderFromSelection() {
+    void openConfirmRunInitializesRunOrderFromSelection() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection(); // select Alpha
         controller.moveDown();
@@ -461,7 +461,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void moveRunHighlightDown_navigatesRunList() {
+    void moveRunHighlightDownNavigatesRunList() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection();
         controller.moveDown();
@@ -475,7 +475,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void moveRunHighlightUp_wrapsAround() {
+    void moveRunHighlightUpWrapsAround() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection();
         controller.moveDown();
@@ -489,7 +489,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void moveRunRecipeDown_reordersRecipes() {
+    void moveRunRecipeDownReordersRecipes() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection(); // select Alpha
         controller.moveDown();
@@ -506,7 +506,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void moveRunRecipeUp_reordersRecipes() {
+    void moveRunRecipeUpReordersRecipes() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection();
         controller.moveDown();
@@ -524,7 +524,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void toggleRunRecipe_togglesIndividualRecipeSelection() {
+    void toggleRunRecipeTogglesIndividualRecipeSelection() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection();
         controller.moveDown();
@@ -542,7 +542,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void cycleRunSelection_cyclesAllNone() {
+    void cycleRunSelectionCyclesAllNone() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection();
         controller.moveDown();
@@ -560,7 +560,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void flattenRunRecipe_replacesCompositeWithSubRecipes() {
+    void flattenRunRecipeReplacesCompositeWithSubRecipes() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite
         controller.toggleSelection(); // select Composite only
@@ -574,7 +574,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void flattenRunRecipe_nonComposite_doesNothing() {
+    void flattenRunRecipeNonCompositeDoesNothing() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection(); // select Alpha
         controller.openConfirmRun();
@@ -586,7 +586,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void expandRunRecipe_addsToRunExpandedSet() {
+    void expandRunRecipeAddsToRunExpandedSet() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite
         controller.toggleSelection();
@@ -599,7 +599,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void collapseRunRecipe_removesFromRunExpandedSet() {
+    void collapseRunRecipeRemovesFromRunExpandedSet() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown();
         controller.toggleSelection();
@@ -615,7 +615,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void displayRows_withoutExpansion_containsOnlyParentRows() {
+    void displayRowsWithoutExpansionContainsOnlyParentRows() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
 
         List<DisplayRow> rows = controller.displayRows();
@@ -629,7 +629,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void displayRows_withExpansion_includesSubRecipeRows() {
+    void displayRowsWithExpansionIncludesSubRecipeRows() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
 
@@ -651,7 +651,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.12"})
-    void moveDown_navigatesExpandedDisplayRows() {
+    void moveDownNavigatesExpandedDisplayRows() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
 
@@ -667,7 +667,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.12"})
-    void moveUp_navigatesExpandedDisplayRows() {
+    void moveUpNavigatesExpandedDisplayRows() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
 
@@ -680,7 +680,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void highlightedDisplayRow_returnsCorrectRow() {
+    void highlightedDisplayRowReturnsCorrectRow() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
         controller.moveDown(); // Composite
@@ -695,7 +695,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void collapseRecipe_clampsHighlightIndex() {
+    void collapseRecipeClampsHighlightIndex() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
         // Navigate to Sub2 (index 3)
@@ -714,7 +714,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.17"})
-    void toggleSelection_selectingComposite_cascadeSelectsCompositeAndAllSubs() {
+    void toggleSelectionSelectingCompositeCascadeSelectsCompositeAndAllSubs() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
         controller.moveDown(); // highlight Composite (index 1)
@@ -729,7 +729,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void toggleSelection_onSubRecipe_selectsSubRecipeIndividually() {
+    void toggleSelectionOnSubRecipeSelectsSubRecipeIndividually() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
         controller.moveDown(); // Composite
@@ -742,7 +742,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void toggleSelection_onSubRecipe_deselectsSubRecipeIndividually() {
+    void toggleSelectionOnSubRecipeDeselectsSubRecipeIndividually() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
         controller.moveDown(); // Composite
@@ -756,7 +756,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void cycleSelection_selectsAllVisibleNames() {
+    void cycleSelectionSelectsAllVisibleNames() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
 
@@ -771,7 +771,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void runDisplayRows_withExpandedComposite_includesSubRecipes() {
+    void runDisplayRowsWithExpandedCompositeIncludesSubRecipes() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite
         controller.toggleSelection(); // select Composite
@@ -791,7 +791,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void moveRunHighlightDown_navigatesExpandedRunDisplayRows() {
+    void moveRunHighlightDownNavigatesExpandedRunDisplayRows() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite
         controller.toggleSelection(); // select Composite
@@ -808,7 +808,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001"})
-    void clearAll_resetsSearchTagsAndSelections() {
+    void clearAllResetsSearchTagsAndSelections() {
         TuiController controller = new TuiController(RECIPES);
         controller.setSearchQuery("alpha");
         controller.toggleTag("java");
@@ -826,7 +826,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void displayRows_nestedComposite_hasCorrectDepth() {
+    void displayRowsNestedCompositeHasCorrectDepth() {
         TuiController controller = new TuiController(RECIPES_WITH_NESTED);
         controller.expandRecipe("org.test.Outer");
 
@@ -850,7 +850,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void displayRows_deeplyNested_expandsBothLevels() {
+    void displayRowsDeeplyNestedExpandsBothLevels() {
         TuiController controller = new TuiController(RECIPES_WITH_NESTED);
         controller.expandRecipe("org.test.Outer");
         controller.expandRecipe("org.test.Composite");
@@ -877,7 +877,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void expandRecipe_onNestedSubRecipe_expandsIt() {
+    void expandRecipeOnNestedSubRecipeExpandsIt() {
         TuiController controller = new TuiController(RECIPES_WITH_NESTED);
         controller.expandRecipe("org.test.Outer");
 
@@ -889,7 +889,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void toggleSelection_onNestedSubRecipe_selectsIndividually() {
+    void toggleSelectionOnNestedSubRecipeSelectsIndividually() {
         TuiController controller = new TuiController(RECIPES_WITH_NESTED);
         controller.expandRecipe("org.test.Outer");
         controller.expandRecipe("org.test.Composite");
@@ -919,7 +919,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void toggleSelection_sameRecipeAtDifferentPositions_selectsByRecipeName() {
+    void toggleSelectionSameRecipeAtDifferentPositionsSelectsByRecipeName() {
         TuiController controller = new TuiController(RECIPES_WITH_DUPLICATE);
         // Sorted by name: Common(0), CompositeCommon(1)
         controller.expandRecipe("org.test.CompositeCommon");
@@ -947,7 +947,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void expandRecipe_sameCompositeAtDifferentPositions_expandsAllInstances() {
+    void expandRecipeSameCompositeAtDifferentPositionsExpandsAllInstances() {
         TuiController controller = new TuiController(RECIPES_WITH_DUPLICATE_COMPOSITE);
         // Sorted: Composite(0), NestedHost(1)
         controller.expandRecipe("org.test.NestedHost");
@@ -983,7 +983,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001"})
-    void toggleHelp_togglesHelpState() {
+    void toggleHelpTogglesHelpState() {
         TuiController controller = new TuiController(RECIPES);
 
         assertThat(controller.isShowHelp()).isFalse();
@@ -1001,7 +1001,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.16"})
-    void coveredRecipes_returnsSubRecipesOfSelectedComposites() {
+    void coveredRecipesReturnsSubRecipesOfSelectedComposites() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite
         controller.toggleSelection(); // select Composite
@@ -1013,7 +1013,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.16.1"})
-    void coveredRecipes_recursivelyIncludesNestedSubRecipes() {
+    void coveredRecipesRecursivelyIncludesNestedSubRecipes() {
         TuiController controller = new TuiController(RECIPES_WITH_NESTED);
         // Sorted: Alpha(0), Gamma(1), Outer(2) — highlight Outer
         controller.moveDown(); // Gamma
@@ -1029,7 +1029,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.16"})
-    void coveredRecipes_emptyWhenNoCompositesSelected() {
+    void coveredRecipesEmptyWhenNoCompositesSelected() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.toggleSelection(); // select Alpha (non-composite)
 
@@ -1040,7 +1040,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.16"})
-    void coveredRecipes_doesNotIncludeTheSelectedCompositeItself() {
+    void coveredRecipesDoesNotIncludeTheSelectedCompositeItself() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite
         controller.toggleSelection(); // select Composite
@@ -1052,7 +1052,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.16.2"})
-    void includedIn_returnsParentCompositesForCoveredRecipe() {
+    void includedInReturnsParentCompositesForCoveredRecipe() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite
         controller.toggleSelection(); // select Composite
@@ -1064,7 +1064,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.16.2"})
-    void includedIn_returnsEmptyForNonCoveredRecipe() {
+    void includedInReturnsEmptyForNonCoveredRecipe() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite
         controller.toggleSelection(); // select Composite
@@ -1078,7 +1078,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.17"})
-    void toggleSelection_selectingComposite_subRecipesAndCompositeAllSelected() {
+    void toggleSelectionSelectingCompositeSubRecipesAndCompositeAllSelected() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite (sorted: Alpha, Composite, Gamma)
 
@@ -1092,7 +1092,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.17.1"})
-    void toggleSelection_selectingAllSubRecipes_cascadeUpSelectsComposite() {
+    void toggleSelectionSelectingAllSubRecipesCascadeUpSelectsComposite() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
         // Sorted + expanded: Alpha(0), Composite(1), Sub1(2), Sub2(3), Gamma(4)
@@ -1114,7 +1114,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.17.2"})
-    void toggleSelection_deselectingComposite_alsoDeselectsExplicitlySelectedSubs() {
+    void toggleSelectionDeselectingCompositeAlsoDeselectsExplicitlySelectedSubs() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
         // Sorted + expanded: Alpha(0), Composite(1), Sub1(2), Sub2(3), Gamma(4)
@@ -1137,7 +1137,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.17.3"})
-    void toggleSelection_selectingOneSub_compositeBecomesPartial() {
+    void toggleSelectionSelectingOneSubCompositeBecomesPartial() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
         // Sorted + expanded: Alpha(0), Composite(1), Sub1(2), Sub2(3), Gamma(4)
@@ -1154,7 +1154,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.17.3"})
-    void deselectingOneSub_leavesPartialState_onComposite() {
+    void deselectingOneSubLeavesPartialStateOnComposite() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
         // Alpha(0), Composite(1), Sub1(2), Sub2(3), Gamma(4)
@@ -1176,7 +1176,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
-    void runDialog_notAffectedByCascade_simpleToggle() {
+    void runDialogNotAffectedByCascadeSimpleToggle() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // Composite (sorted: Alpha, Composite, Gamma)
         controller.toggleSelection(); // cascade selects Composite + Sub1 + Sub2
@@ -1195,7 +1195,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.5"})
-    void cycleSelection_withCascade_recomputesPartialState() {
+    void cycleSelectionWithCascadeRecomputesPartialState() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
 
@@ -1213,7 +1213,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.13"})
-    void displayRows_pathFieldIsCorrectForAllPositions() {
+    void displayRowsPathFieldIsCorrectForAllPositions() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.expandRecipe("org.test.Composite");
 

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -366,7 +366,8 @@ class TuiControllerTest {
         controller.saveRunConfig(configFile);
 
         RunConfig loaded = service.load(configFile);
-        assertThat(loaded.recipes()).containsExactlyInAnyOrder("org.test.Alpha", "org.test.Beta");
+        assertThat(loaded.recipes().stream().map(r -> r.name()).toList())
+                .containsExactlyInAnyOrder("org.test.Alpha", "org.test.Beta");
     }
 
     // --- Cycle Selection ---

--- a/atunko-web/build.gradle
+++ b/atunko-web/build.gradle
@@ -20,3 +20,18 @@ dependencies {
     // Testing
     testImplementation libs.karibu.testing
 }
+
+testing {
+    suites {
+        integrationTest(JvmTestSuite) {
+            useJUnitJupiter()
+            dependencies {
+                implementation project()
+                implementation libs.playwright
+            }
+        }
+    }
+}
+
+// Integration tests need access to all main implementation deps (VaadinBoot, Vaadin, etc.)
+configurations.integrationTestImplementation.extendsFrom(configurations.implementation)

--- a/atunko-web/build.gradle
+++ b/atunko-web/build.gradle
@@ -35,3 +35,10 @@ testing {
 
 // Integration tests need access to all main implementation deps (VaadinBoot, Vaadin, etc.)
 configurations.integrationTestImplementation.extendsFrom(configurations.implementation)
+
+// Task to install Playwright browsers via the Playwright CLI
+tasks.register('playwrightInstall', JavaExec) {
+    classpath = configurations.integrationTestRuntimeClasspath + sourceSets.integrationTest.output
+    mainClass = 'com.microsoft.playwright.CLI'
+    args = ['install', '--with-deps', 'chromium']
+}

--- a/atunko-web/src/integrationTest/java/io/github/atunkodev/web/DiffDialogE2eTest.java
+++ b/atunko-web/src/integrationTest/java/io/github/atunkodev/web/DiffDialogE2eTest.java
@@ -1,0 +1,52 @@
+package io.github.atunkodev.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page.GetByRoleOptions;
+import com.microsoft.playwright.options.AriaRole;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Playwright e2e tests for features that require real browser rendering: diff2html JavaScript
+ * rendering, side-by-side diff layout.
+ */
+class DiffDialogE2eTest extends PlaywrightTestBase {
+
+    @Test
+    void pageLoadsRecipeBrowserVisible() {
+        navigateTo("/");
+        assertThat(page).hasTitle("atunko");
+        assertThat(page.locator("vaadin-app-layout")).isVisible();
+    }
+
+    @Test
+    void dryRunRendersDiff2htmlSideBySide() {
+        navigateTo("/");
+
+        // Select the leaf recipe in the tree grid
+        page.locator("vaadin-grid-tree-toggle").first().click();
+
+        // Click Dry Run button
+        page.getByRole(AriaRole.BUTTON, new GetByRoleOptions().setName("Dry Run"))
+                .click();
+
+        // RunOrderDialog opens — click Confirm
+        page.getByRole(AriaRole.BUTTON, new GetByRoleOptions().setName("Confirm"))
+                .click();
+
+        // Wait for the DiffDialog to appear with diff2html content
+        Locator diffWrapper = page.locator(".d2h-wrapper");
+        diffWrapper.first().waitFor();
+
+        // Verify diff2html rendered with side-by-side layout
+        assertThat(diffWrapper.first()).isVisible();
+        assertThat(page.locator(".d2h-file-wrapper").first()).isVisible();
+
+        // Verify the diff contains our test file
+        assertThat(page.locator(".d2h-file-header").first()).containsText("Hello.java");
+
+        // Verify side-by-side columns are present
+        assertThat(page.locator(".d2h-file-side-diff").first()).isVisible();
+    }
+}

--- a/atunko-web/src/integrationTest/java/io/github/atunkodev/web/DiffDialogE2eTest.java
+++ b/atunko-web/src/integrationTest/java/io/github/atunkodev/web/DiffDialogE2eTest.java
@@ -16,7 +16,7 @@ class DiffDialogE2eTest extends PlaywrightTestBase {
     @Test
     void pageLoadsRecipeBrowserVisible() {
         navigateTo("/");
-        assertThat(page).hasTitle("atunko");
+        page.locator("vaadin-app-layout").waitFor();
         assertThat(page.locator("vaadin-app-layout")).isVisible();
     }
 

--- a/atunko-web/src/integrationTest/java/io/github/atunkodev/web/DiffDialogE2eTest.java
+++ b/atunko-web/src/integrationTest/java/io/github/atunkodev/web/DiffDialogE2eTest.java
@@ -8,8 +8,8 @@ import com.microsoft.playwright.options.AriaRole;
 import org.junit.jupiter.api.Test;
 
 /**
- * Playwright e2e tests for features that require real browser rendering: diff2html JavaScript
- * rendering, side-by-side diff layout.
+ * Playwright integration tests for features that require real browser rendering: diff2html
+ * JavaScript rendering, side-by-side diff layout.
  */
 class DiffDialogE2eTest extends PlaywrightTestBase {
 
@@ -24,20 +24,26 @@ class DiffDialogE2eTest extends PlaywrightTestBase {
     void dryRunRendersDiff2htmlSideBySide() {
         navigateTo("/");
 
-        // Select the leaf recipe in the tree grid
-        page.locator("vaadin-grid-tree-toggle").first().click();
+        // Wait for the grid to be fully loaded
+        page.locator("vaadin-grid-cell-content").first().waitFor();
+
+        // Select the recipe by clicking the row's checkbox
+        page.locator("vaadin-grid-tree-column vaadin-checkbox, vaadin-checkbox")
+                .first()
+                .click();
 
         // Click Dry Run button
         page.getByRole(AriaRole.BUTTON, new GetByRoleOptions().setName("Dry Run"))
                 .click();
 
         // RunOrderDialog opens — click Confirm
-        page.getByRole(AriaRole.BUTTON, new GetByRoleOptions().setName("Confirm"))
-                .click();
+        Locator confirmButton = page.getByRole(AriaRole.BUTTON, new GetByRoleOptions().setName("Confirm"));
+        confirmButton.waitFor();
+        confirmButton.click();
 
-        // Wait for the DiffDialog to appear with diff2html content
+        // Wait for the DiffDialog to appear with diff2html content (may take time in CI)
         Locator diffWrapper = page.locator(".d2h-wrapper");
-        diffWrapper.first().waitFor();
+        diffWrapper.first().waitFor(new Locator.WaitForOptions().setTimeout(60000));
 
         // Verify diff2html rendered with side-by-side layout
         assertThat(diffWrapper.first()).isVisible();

--- a/atunko-web/src/integrationTest/java/io/github/atunkodev/web/DiffDialogIntegrationTest.java
+++ b/atunko-web/src/integrationTest/java/io/github/atunkodev/web/DiffDialogIntegrationTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
  * Playwright integration tests for features that require real browser rendering: diff2html
  * JavaScript rendering, side-by-side diff layout.
  */
-class DiffDialogE2eTest extends PlaywrightTestBase {
+class DiffDialogIntegrationTest extends PlaywrightTestBase {
 
     @Test
     void pageLoadsRecipeBrowserVisible() {
@@ -28,9 +28,7 @@ class DiffDialogE2eTest extends PlaywrightTestBase {
         page.locator("vaadin-grid-cell-content").first().waitFor();
 
         // Select the recipe by clicking the row's checkbox
-        page.locator("vaadin-grid-tree-column vaadin-checkbox, vaadin-checkbox")
-                .first()
-                .click();
+        page.locator("vaadin-grid vaadin-checkbox").first().click();
 
         // Click Dry Run button
         page.getByRole(AriaRole.BUTTON, new GetByRoleOptions().setName("Dry Run"))

--- a/atunko-web/src/integrationTest/java/io/github/atunkodev/web/PlaywrightTestBase.java
+++ b/atunko-web/src/integrationTest/java/io/github/atunkodev/web/PlaywrightTestBase.java
@@ -1,0 +1,130 @@
+package io.github.atunkodev.web;
+
+import com.github.mvysny.vaadinboot.VaadinBoot;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import io.github.atunkodev.core.AppServices;
+import io.github.atunkodev.core.engine.ChangeApplier;
+import io.github.atunkodev.core.engine.ExecutionResult;
+import io.github.atunkodev.core.engine.FileChange;
+import io.github.atunkodev.core.engine.RecipeExecutionEngine;
+import io.github.atunkodev.core.project.ProjectInfo;
+import io.github.atunkodev.core.project.ProjectSourceParser;
+import io.github.atunkodev.core.project.SessionHolder;
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Base class for Playwright e2e tests. Starts VaadinBoot on a random port with stub services that
+ * produce canned diff output so that browser-rendered features (diff2html, badges) can be verified.
+ */
+abstract class PlaywrightTestBase {
+
+    static final RecipeInfo LEAF_RECIPE =
+            new RecipeInfo("org.test.Alpha", "Alpha Recipe", "Test recipe", Set.of("java"));
+
+    private static VaadinBoot boot;
+    private static int port;
+
+    static Playwright playwright;
+    static Browser browser;
+    BrowserContext context;
+    Page page;
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        port = findFreePort();
+
+        RecipeHolder.init(List.of(LEAF_RECIPE));
+        SessionHolder.init(Path.of("."), new ProjectInfo(List.of(), List.of()));
+
+        AppServices.init(stubEngine(), stubParser(), stubApplier());
+
+        boot = new VaadinBoot();
+        boot.withPort(port);
+        boot.start();
+
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch();
+    }
+
+    @AfterAll
+    static void stopServer() throws Exception {
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+        if (boot != null) {
+            boot.stop("e2e tests finished");
+        }
+    }
+
+    @BeforeEach
+    void createPage() {
+        context = browser.newContext();
+        page = context.newPage();
+    }
+
+    @AfterEach
+    void closePage() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    String baseUrl() {
+        return "http://localhost:" + port;
+    }
+
+    void navigateTo(String path) {
+        page.navigate(baseUrl() + path);
+    }
+
+    private static RecipeExecutionEngine stubEngine() {
+        return new RecipeExecutionEngine() {
+            @Override
+            public ExecutionResult execute(String recipeName, List<org.openrewrite.SourceFile> sources) {
+                return new ExecutionResult(List.of(new FileChange(
+                        Path.of("src/main/java/Hello.java"),
+                        "public class Hello {\n    // old\n}\n",
+                        "public class Hello {\n    // new\n}\n")));
+            }
+        };
+    }
+
+    private static ProjectSourceParser stubParser() {
+        return new ProjectSourceParser() {
+            @Override
+            public List<org.openrewrite.SourceFile> parse(ProjectInfo projectInfo) {
+                return List.of();
+            }
+        };
+    }
+
+    private static ChangeApplier stubApplier() {
+        return new ChangeApplier() {
+            @Override
+            public void apply(Path projectDir, List<FileChange> changes) {
+                // no-op for e2e tests
+            }
+        };
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/DiffDialog.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/DiffDialog.java
@@ -16,17 +16,22 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.virtuallist.VirtualList;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
  * GitHub/GitLab-style diff dialog powered by diff2html.
  *
- * <p>Left panel: filterable file list. Right panel: side-by-side diff for the selected file.
+ * <p>Left panel: filterable file list (virtualized). Right panel: side-by-side diff for the
+ * selected file.
  */
 @NpmPackage(value = "diff2html", version = "3.4.56")
 @JsModule("./diff2html-init.js")
@@ -39,13 +44,13 @@ public class DiffDialog extends Dialog {
     private FileChange selectedChange;
     private String filterText = "";
 
-    private final Div fileListContainer = new Div();
+    private final VirtualList<FileChange> fileList = new VirtualList<>();
     private final Div diffContainer = new Div();
     private final String diffContainerId =
             "diff-" + UUID.randomUUID().toString().replace("-", "");
 
     public DiffDialog(ExecutionResult result, boolean dryRun) {
-        this.changes = result.changes();
+        this.changes = deduplicateChanges(result.changes());
 
         setHeaderTitle(
                 (dryRun ? "Dry Run Preview" : "Execution Results") + " — " + changes.size() + " file(s) changed");
@@ -96,10 +101,13 @@ public class DiffDialog extends Dialog {
             refreshFileList();
         });
 
-        fileListContainer.getStyle().set("overflow-y", "auto");
+        fileList.setRenderer(new ComponentRenderer<>(this::renderFileItem));
+        fileList.setWidthFull();
+        fileList.setHeightFull();
+        refreshFileList();
 
         panel.add(filter);
-        panel.addAndExpand(fileListContainer);
+        panel.addAndExpand(fileList);
         return panel;
     }
 
@@ -112,14 +120,14 @@ public class DiffDialog extends Dialog {
     // --- File list ---
 
     private void refreshFileList() {
-        fileListContainer.removeAll();
-        changes.stream()
+        List<FileChange> filtered = changes.stream()
                 .filter(c -> filterText.isBlank()
                         || c.path().toString().toLowerCase().contains(filterText.toLowerCase()))
-                .forEach(c -> fileListContainer.add(buildFileItem(c)));
+                .toList();
+        fileList.setItems(filtered);
     }
 
-    private Div buildFileItem(FileChange change) {
+    private Div renderFileItem(FileChange change) {
         boolean selected = change.equals(selectedChange);
         String fileName = change.path().getFileName().toString();
         String dir =
@@ -164,7 +172,7 @@ public class DiffDialog extends Dialog {
 
     private void selectChange(FileChange change) {
         selectedChange = change;
-        refreshFileList();
+        fileList.getDataProvider().refreshAll();
         String diffString = buildUnifiedDiff(change);
         UI.getCurrent()
                 .getPage()
@@ -188,5 +196,17 @@ public class DiffDialog extends Dialog {
             return List.of();
         }
         return Arrays.asList(text.replace("\r\n", "\n").split("\n", -1));
+    }
+
+    /**
+     * Deduplicates file changes by path, keeping the last change for each file. When multiple
+     * recipes modify the same file, only the final state matters.
+     */
+    static List<FileChange> deduplicateChanges(List<FileChange> changes) {
+        Map<String, FileChange> byPath = new LinkedHashMap<>();
+        for (FileChange change : changes) {
+            byPath.put(change.path().toString(), change);
+        }
+        return List.copyOf(byPath.values());
     }
 }

--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeBrowserView.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeBrowserView.java
@@ -49,6 +49,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.openrewrite.SourceFile;
@@ -75,6 +77,7 @@ public class RecipeBrowserView extends AppLayout {
     private Set<RecipeInfo> coveredRecipes = Set.of();
     private SortOrder currentSortOrder = SortOrder.NAME;
     private final RunConfigService runConfigService = new RunConfigService();
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     public RecipeBrowserView() {
         allRecipes = RecipeHolder.getRecipes();
@@ -318,13 +321,18 @@ public class RecipeBrowserView extends AppLayout {
             return;
         }
 
-        new RunOrderDialog(selected, dryRun, ordered -> executeRecipes(ordered, dryRun)).open();
-    }
-
-    private void executeRecipes(List<RecipeInfo> recipes, boolean dryRun) {
         dryRunButton.setEnabled(false);
         executeButton.setEnabled(false);
 
+        Runnable onCancel = () -> {
+            dryRunButton.setEnabled(true);
+            executeButton.setEnabled(true);
+        };
+
+        new RunOrderDialog(selected, dryRun, ordered -> executeRecipes(ordered, dryRun), onCancel).open();
+    }
+
+    private void executeRecipes(List<RecipeInfo> recipes, boolean dryRun) {
         Dialog progressDialog = new Dialog();
         progressDialog.setCloseOnEsc(false);
         progressDialog.setCloseOnOutsideClick(false);
@@ -339,57 +347,54 @@ public class RecipeBrowserView extends AppLayout {
 
         UI ui = UI.getCurrent();
 
-        new Thread(() -> {
+        executor.submit(() -> {
+            try {
+                ProjectInfo projectInfo = SessionHolder.getProjectInfo();
+                Path projectDir = SessionHolder.getProjectDir();
+                List<SourceFile> sources;
+                if (projectInfo != null) {
+                    sources = AppServices.getSourceParser().parse(projectInfo);
+                } else {
+                    sources = AppServices.getSourceParser().parse(new ProjectInfo(List.of(), List.of(projectDir)));
+                }
+
+                List<FileChange> allChanges = new ArrayList<>();
+                List<String> failedRecipes = new ArrayList<>();
+                for (RecipeInfo recipe : recipes) {
                     try {
-                        ProjectInfo projectInfo = SessionHolder.getProjectInfo();
-                        Path projectDir = SessionHolder.getProjectDir();
-                        List<SourceFile> sources;
-                        if (projectInfo != null) {
-                            sources = AppServices.getSourceParser().parse(projectInfo);
-                        } else {
-                            sources = AppServices.getSourceParser()
-                                    .parse(new ProjectInfo(List.of(), List.of(projectDir)));
-                        }
-
-                        List<FileChange> allChanges = new ArrayList<>();
-                        List<String> failedRecipes = new ArrayList<>();
-                        for (RecipeInfo recipe : recipes) {
-                            try {
-                                ExecutionResult result = AppServices.getEngine().execute(recipe.name(), sources);
-                                allChanges.addAll(result.changes());
-                            } catch (Exception recipeEx) {
-                                failedRecipes.add(recipe.displayName() + ": " + recipeEx.getMessage());
-                            }
-                        }
-                        ExecutionResult combined = new ExecutionResult(allChanges);
-
-                        if (!dryRun && AppServices.getChangeApplier() != null) {
-                            AppServices.getChangeApplier().apply(projectDir, combined.changes());
-                        }
-
-                        ui.access(() -> {
-                            progressDialog.close();
-                            new DiffDialog(combined, dryRun).open();
-                            if (!failedRecipes.isEmpty()) {
-                                Notification.show(
-                                        failedRecipes.size() + " recipe(s) failed:\n"
-                                                + String.join("\n", failedRecipes),
-                                        8000,
-                                        Notification.Position.MIDDLE);
-                            }
-                            dryRunButton.setEnabled(true);
-                            executeButton.setEnabled(true);
-                        });
-                    } catch (Exception e) {
-                        ui.access(() -> {
-                            progressDialog.close();
-                            Notification.show("Error: " + e.getMessage(), 5000, Notification.Position.MIDDLE);
-                            dryRunButton.setEnabled(true);
-                            executeButton.setEnabled(true);
-                        });
+                        ExecutionResult result = AppServices.getEngine().execute(recipe.name(), sources);
+                        allChanges.addAll(result.changes());
+                    } catch (Exception recipeEx) {
+                        failedRecipes.add(recipe.displayName() + ": " + recipeEx.getMessage());
                     }
-                })
-                .start();
+                }
+                ExecutionResult combined = new ExecutionResult(allChanges);
+
+                if (!dryRun && AppServices.getChangeApplier() != null) {
+                    AppServices.getChangeApplier().apply(projectDir, combined.changes());
+                }
+
+                ui.access(() -> {
+                    progressDialog.close();
+                    new DiffDialog(combined, dryRun).open();
+                    if (!failedRecipes.isEmpty()) {
+                        Notification.show(
+                                failedRecipes.size() + " recipe(s) failed:\n" + String.join("\n", failedRecipes),
+                                8000,
+                                Notification.Position.MIDDLE);
+                    }
+                    dryRunButton.setEnabled(true);
+                    executeButton.setEnabled(true);
+                });
+            } catch (Exception e) {
+                ui.access(() -> {
+                    progressDialog.close();
+                    Notification.show("Error: " + e.getMessage(), 5000, Notification.Position.MIDDLE);
+                    dryRunButton.setEnabled(true);
+                    executeButton.setEnabled(true);
+                });
+            }
+        });
     }
 
     // --- Testability hooks ---

--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeBrowserView.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeBrowserView.java
@@ -88,6 +88,7 @@ public class RecipeBrowserView extends AppLayout {
         content.setSizeFull();
         content.setPadding(false);
         content.setSpacing(false);
+        content.getStyle().set("overflow", "hidden");
 
         content.add(buildSearchBar());
         content.addAndExpand(buildSplitLayout());
@@ -351,9 +352,14 @@ public class RecipeBrowserView extends AppLayout {
                         }
 
                         List<FileChange> allChanges = new ArrayList<>();
+                        List<String> failedRecipes = new ArrayList<>();
                         for (RecipeInfo recipe : recipes) {
-                            ExecutionResult result = AppServices.getEngine().execute(recipe.name(), sources);
-                            allChanges.addAll(result.changes());
+                            try {
+                                ExecutionResult result = AppServices.getEngine().execute(recipe.name(), sources);
+                                allChanges.addAll(result.changes());
+                            } catch (Exception recipeEx) {
+                                failedRecipes.add(recipe.displayName() + ": " + recipeEx.getMessage());
+                            }
                         }
                         ExecutionResult combined = new ExecutionResult(allChanges);
 
@@ -364,6 +370,13 @@ public class RecipeBrowserView extends AppLayout {
                         ui.access(() -> {
                             progressDialog.close();
                             new DiffDialog(combined, dryRun).open();
+                            if (!failedRecipes.isEmpty()) {
+                                Notification.show(
+                                        failedRecipes.size() + " recipe(s) failed:\n"
+                                                + String.join("\n", failedRecipes),
+                                        8000,
+                                        Notification.Position.MIDDLE);
+                            }
                             dryRunButton.setEnabled(true);
                             executeButton.setEnabled(true);
                         });

--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeBrowserView.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeBrowserView.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.progressbar.ProgressBar;
+import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.treegrid.TreeGrid;
@@ -27,13 +28,19 @@ import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 import io.github.atunkodev.core.AppServices;
+import io.github.atunkodev.core.config.RecipeEntry;
+import io.github.atunkodev.core.config.RunConfig;
+import io.github.atunkodev.core.config.RunConfigService;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
 import io.github.atunkodev.core.project.ProjectInfo;
 import io.github.atunkodev.core.project.SessionHolder;
 import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.atunkodev.core.recipe.SortOrder;
 import io.github.atunkodev.web.RecipeHolder;
 import io.github.reqstool.annotations.Requirements;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.openrewrite.SourceFile;
 
 @Route("")
@@ -63,9 +71,14 @@ public class RecipeBrowserView extends AppLayout {
     private RecipeInfo detailRecipe;
     private CascadeSelectionHandler cascadeHandler;
     private boolean inCascadeUpdate = false;
+    private Map<RecipeInfo, List<RecipeInfo>> childToParents;
+    private Set<RecipeInfo> coveredRecipes = Set.of();
+    private SortOrder currentSortOrder = SortOrder.NAME;
+    private final RunConfigService runConfigService = new RunConfigService();
 
     public RecipeBrowserView() {
         allRecipes = RecipeHolder.getRecipes();
+        childToParents = RecipeCoverageUtils.buildReverseIndex(allRecipes);
 
         H2 title = new H2("atunko");
         title.getStyle().set("margin", "0 auto");
@@ -87,6 +100,7 @@ public class RecipeBrowserView extends AppLayout {
         applyFilters();
     }
 
+    @Requirements({"atunko:WEB_0001.13"})
     private Component buildSearchBar() {
         searchField.setPlaceholder("Search recipes...");
         searchField.setWidthFull();
@@ -95,7 +109,20 @@ public class RecipeBrowserView extends AppLayout {
             currentTextQuery = e.getValue();
             applyFilters();
         });
-        return searchField;
+
+        Select<SortOrder> sortSelect = new Select<>();
+        sortSelect.setItems(SortOrder.NAME, SortOrder.TAGS);
+        sortSelect.setValue(SortOrder.NAME);
+        sortSelect.setItemLabelGenerator(s -> s == SortOrder.NAME ? "Sort: Name" : "Sort: Tags");
+        sortSelect.addValueChangeListener(e -> {
+            currentSortOrder = e.getValue();
+            applyFilters();
+        });
+
+        HorizontalLayout bar = new HorizontalLayout(searchField, sortSelect);
+        bar.setWidthFull();
+        bar.expand(searchField);
+        return bar;
     }
 
     private Component buildSplitLayout() {
@@ -114,15 +141,28 @@ public class RecipeBrowserView extends AppLayout {
         return split;
     }
 
-    @Requirements({"atunko:WEB_0001.9"})
+    @Requirements({"atunko:WEB_0001.9", "atunko:WEB_0001.11", "atunko:WEB_0001.12", "atunko:WEB_0001.14"})
     private Component buildStatusBar() {
+        Button selectAllButton = new Button("Select All", VaadinIcon.CHECK_SQUARE_O.create(), e -> selectAllVisible());
+        selectAllButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+
+        Button deselectAllButton = new Button("Deselect All", VaadinIcon.THIN_SQUARE.create(), e -> deselectAll());
+        deselectAllButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+
+        Button saveButton = new Button("Save", VaadinIcon.DOWNLOAD.create(), e -> saveConfig());
+        saveButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+
+        Button loadButton = new Button("Load", VaadinIcon.UPLOAD.create(), e -> loadConfig());
+        loadButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+
         dryRunButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
         dryRunButton.addClickListener(e -> runRecipes(true));
 
         executeButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
         executeButton.addClickListener(e -> runRecipes(false));
 
-        HorizontalLayout bar = new HorizontalLayout(statusBar, dryRunButton, executeButton);
+        HorizontalLayout bar = new HorizontalLayout(
+                statusBar, selectAllButton, deselectAllButton, saveButton, loadButton, dryRunButton, executeButton);
         bar.setWidthFull();
         bar.setAlignItems(HorizontalLayout.Alignment.CENTER);
         return bar;
@@ -134,7 +174,18 @@ public class RecipeBrowserView extends AppLayout {
         treeGrid.addThemeVariants(GridVariant.LUMO_ROW_STRIPES);
         treeGrid.setSelectionMode(TreeGrid.SelectionMode.MULTI);
 
-        treeGrid.addHierarchyColumn(node -> node.recipe().displayName())
+        treeGrid.addComponentHierarchyColumn(node -> {
+                    Span name = new Span(node.recipe().displayName());
+                    if (coveredRecipes.contains(node.recipe())) {
+                        Span badge = new Span("covered");
+                        badge.getElement().getThemeList().addAll(List.of("badge", "contrast", "small"));
+                        HorizontalLayout row = new HorizontalLayout(name, badge);
+                        row.setAlignItems(HorizontalLayout.Alignment.CENTER);
+                        row.setSpacing(true);
+                        return row;
+                    }
+                    return name;
+                })
                 .setHeader("Name")
                 .setSortable(true);
 
@@ -173,6 +224,7 @@ public class RecipeBrowserView extends AppLayout {
             } finally {
                 inCascadeUpdate = false;
             }
+            updateCoveredRecipes();
             Set<TreeNode> all = treeGrid.getSelectedItems();
             if (!all.isEmpty()) {
                 selectForDetail(all.iterator().next().recipe());
@@ -184,8 +236,19 @@ public class RecipeBrowserView extends AppLayout {
         detailPanel.add(new Span("Select a recipe to view details"));
     }
 
+    @Requirements({"atunko:WEB_0001.15"})
+    private void updateCoveredRecipes() {
+        if (cascadeHandler == null) {
+            return;
+        }
+        coveredRecipes = RecipeCoverageUtils.computeCovered(cascadeHandler.getSelectedItems());
+        treeGrid.getDataProvider().refreshAll();
+    }
+
     private void applyFilters() {
-        List<RecipeInfo> filtered = RecipeFilter.filter(allRecipes, currentTextQuery, currentTagFilter);
+        List<RecipeInfo> filtered = RecipeFilter.filter(allRecipes, currentTextQuery, currentTagFilter).stream()
+                .sorted(currentSortOrder.comparator())
+                .toList();
 
         TreeData<TreeNode> treeData = new TreeData<>();
         Map<RecipeInfo, List<TreeNode>> recipeToNodes = new HashMap<>();
@@ -243,7 +306,7 @@ public class RecipeBrowserView extends AppLayout {
         }
     }
 
-    @Requirements({"atunko:WEB_0001.9"})
+    @Requirements({"atunko:WEB_0001.9", "atunko:WEB_0001.10"})
     void runRecipes(boolean dryRun) {
         if (AppServices.getEngine() == null || AppServices.getSourceParser() == null) {
             return;
@@ -254,6 +317,10 @@ public class RecipeBrowserView extends AppLayout {
             return;
         }
 
+        new RunOrderDialog(selected, dryRun, ordered -> executeRecipes(ordered, dryRun)).open();
+    }
+
+    private void executeRecipes(List<RecipeInfo> recipes, boolean dryRun) {
         dryRunButton.setEnabled(false);
         executeButton.setEnabled(false);
 
@@ -264,13 +331,12 @@ public class RecipeBrowserView extends AppLayout {
         ProgressBar bar = new ProgressBar();
         bar.setIndeterminate(true);
         bar.setWidth("300px");
-        VerticalLayout progressContent = new VerticalLayout(new Span(selected.size() + " recipe(s) selected"), bar);
+        VerticalLayout progressContent = new VerticalLayout(new Span(recipes.size() + " recipe(s) selected"), bar);
         progressContent.setAlignItems(VerticalLayout.Alignment.CENTER);
         progressDialog.add(progressContent);
         progressDialog.open();
 
         UI ui = UI.getCurrent();
-        Set<RecipeInfo> selectedCopy = Set.copyOf(selected);
 
         new Thread(() -> {
                     try {
@@ -285,7 +351,7 @@ public class RecipeBrowserView extends AppLayout {
                         }
 
                         List<FileChange> allChanges = new ArrayList<>();
-                        for (RecipeInfo recipe : selectedCopy) {
+                        for (RecipeInfo recipe : recipes) {
                             ExecutionResult result = AppServices.getEngine().execute(recipe.name(), sources);
                             allChanges.addAll(result.changes());
                         }
@@ -316,7 +382,9 @@ public class RecipeBrowserView extends AppLayout {
     // --- Testability hooks ---
 
     public List<RecipeInfo> getVisibleRecipes() {
-        return RecipeFilter.filter(allRecipes, currentTextQuery, currentTagFilter);
+        return RecipeFilter.filter(allRecipes, currentTextQuery, currentTagFilter).stream()
+                .sorted(currentSortOrder.comparator())
+                .toList();
     }
 
     @Requirements({"atunko:WEB_0001.2"})
@@ -331,7 +399,7 @@ public class RecipeBrowserView extends AppLayout {
         applyFilters();
     }
 
-    @Requirements({"atunko:WEB_0001.6"})
+    @Requirements({"atunko:WEB_0001.6", "atunko:WEB_0001.16"})
     public void selectForDetail(RecipeInfo recipe) {
         detailRecipe = recipe;
         detailPanel.removeAll();
@@ -342,6 +410,11 @@ public class RecipeBrowserView extends AppLayout {
         if (recipe.isComposite()) {
             detailPanel.add(new Span("Recipe List:"));
             recipe.recipeList().forEach(child -> detailPanel.add(new Span("• " + child.displayName())));
+        }
+        List<RecipeInfo> parents = childToParents.getOrDefault(recipe, List.of());
+        if (!parents.isEmpty()) {
+            String parentNames = parents.stream().map(RecipeInfo::displayName).collect(Collectors.joining(", "));
+            detailPanel.add(new Span("Included in: " + parentNames));
         }
     }
 
@@ -367,5 +440,181 @@ public class RecipeBrowserView extends AppLayout {
 
     public Button getExecuteButton() {
         return executeButton;
+    }
+
+    public Set<RecipeInfo> getCoveredRecipes() {
+        return coveredRecipes;
+    }
+
+    @Requirements({"atunko:WEB_0001.14"})
+    public void selectAllVisible() {
+        if (cascadeHandler == null) {
+            return;
+        }
+        inCascadeUpdate = true;
+        try {
+            for (RecipeInfo recipe : getVisibleRecipes()) {
+                cascadeHandler.selectItem(recipe);
+            }
+        } finally {
+            inCascadeUpdate = false;
+        }
+        updateCoveredRecipes();
+    }
+
+    @Requirements({"atunko:WEB_0001.14"})
+    public void deselectAll() {
+        if (cascadeHandler == null) {
+            return;
+        }
+        inCascadeUpdate = true;
+        try {
+            for (RecipeInfo recipe : Set.copyOf(cascadeHandler.getSelectedItems())) {
+                cascadeHandler.deselectItem(recipe);
+            }
+        } finally {
+            inCascadeUpdate = false;
+        }
+        updateCoveredRecipes();
+    }
+
+    @Requirements({"atunko:WEB_0001.11"})
+    void saveConfig() {
+        if (cascadeHandler == null) {
+            return;
+        }
+        Set<RecipeInfo> selected = cascadeHandler.getSelectedItems();
+        if (selected.isEmpty()) {
+            Notification.show("No recipes selected", 3000, Notification.Position.MIDDLE);
+            return;
+        }
+
+        Dialog nameDialog = new Dialog();
+        nameDialog.setHeaderTitle("Save Run Configuration");
+        TextField nameField = new TextField("Name");
+        nameField.setWidthFull();
+        nameDialog.add(nameField);
+
+        Button cancelButton = new Button("Cancel", e -> nameDialog.close());
+        cancelButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+        Button confirmButton = new Button("Save", e -> {
+            String name = nameField.getValue().trim();
+            if (name.isEmpty()) {
+                Notification.show("Name is required", 3000, Notification.Position.MIDDLE);
+                return;
+            }
+            try {
+                Path runsDir = SessionHolder.getProjectDir().resolve("atunko/runs");
+                Files.createDirectories(runsDir);
+                Path file = runsDir.resolve(name + ".yaml");
+                List<RecipeEntry> entries =
+                        selected.stream().map(r -> new RecipeEntry(r.name())).toList();
+                RunConfig config = new RunConfig(entries);
+                runConfigService.save(config, file);
+                nameDialog.close();
+                Notification.show("Saved: " + file.getFileName(), 3000, Notification.Position.MIDDLE);
+            } catch (IOException ex) {
+                Notification.show("Save failed: " + ex.getMessage(), 5000, Notification.Position.MIDDLE);
+            }
+        });
+        confirmButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+        nameDialog.getFooter().add(cancelButton, confirmButton);
+        nameDialog.open();
+    }
+
+    @Requirements({"atunko:WEB_0001.12"})
+    void loadConfig() {
+        Path runsDir = SessionHolder.getProjectDir().resolve("atunko/runs");
+        if (!Files.isDirectory(runsDir)) {
+            Notification.show("No saved runs found", 3000, Notification.Position.MIDDLE);
+            return;
+        }
+
+        List<Path> yamlFiles;
+        try (Stream<Path> stream = Files.list(runsDir)) {
+            yamlFiles =
+                    stream.filter(p -> p.toString().endsWith(".yaml")).sorted().toList();
+        } catch (IOException ex) {
+            Notification.show("Failed to list runs: " + ex.getMessage(), 5000, Notification.Position.MIDDLE);
+            return;
+        }
+        if (yamlFiles.isEmpty()) {
+            Notification.show("No saved runs found", 3000, Notification.Position.MIDDLE);
+            return;
+        }
+
+        Dialog pickerDialog = new Dialog();
+        pickerDialog.setHeaderTitle("Load Run Configuration");
+
+        Select<Path> fileSelect = new Select<>();
+        fileSelect.setItems(yamlFiles);
+        fileSelect.setItemLabelGenerator(p -> p.getFileName().toString().replace(".yaml", ""));
+        fileSelect.setWidthFull();
+        pickerDialog.add(fileSelect);
+
+        Button cancelButton = new Button("Cancel", e -> pickerDialog.close());
+        cancelButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+        Button confirmButton = new Button("Load", e -> {
+            Path selected = fileSelect.getValue();
+            if (selected == null) {
+                Notification.show("Select a configuration", 3000, Notification.Position.MIDDLE);
+                return;
+            }
+            try {
+                RunConfig config = runConfigService.load(selected);
+                applyRunConfig(config);
+                pickerDialog.close();
+                Notification.show(
+                        "Loaded: " + selected.getFileName().toString().replace(".yaml", ""),
+                        3000,
+                        Notification.Position.MIDDLE);
+            } catch (IOException ex) {
+                Notification.show("Load failed: " + ex.getMessage(), 5000, Notification.Position.MIDDLE);
+            }
+        });
+        confirmButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+        pickerDialog.getFooter().add(cancelButton, confirmButton);
+        pickerDialog.open();
+    }
+
+    void applyRunConfig(RunConfig config) {
+        Map<String, RecipeInfo> recipeLookup = buildRecipeNameLookup();
+        deselectAll();
+
+        inCascadeUpdate = true;
+        try {
+            for (RecipeEntry entry : config.recipes()) {
+                RecipeInfo recipe = recipeLookup.get(entry.name());
+                if (recipe != null) {
+                    cascadeHandler.selectItem(recipe);
+                }
+            }
+        } finally {
+            inCascadeUpdate = false;
+        }
+        updateCoveredRecipes();
+    }
+
+    private Map<String, RecipeInfo> buildRecipeNameLookup() {
+        Map<String, RecipeInfo> lookup = new HashMap<>();
+        for (RecipeInfo recipe : allRecipes) {
+            addToLookup(recipe, lookup);
+        }
+        return lookup;
+    }
+
+    private void addToLookup(RecipeInfo recipe, Map<String, RecipeInfo> lookup) {
+        lookup.putIfAbsent(recipe.name(), recipe);
+        for (RecipeInfo child : recipe.recipeList()) {
+            if (!lookup.containsKey(child.name())) {
+                addToLookup(child, lookup);
+            }
+        }
+    }
+
+    @Requirements({"atunko:WEB_0001.13"})
+    public void applySortOrder(SortOrder order) {
+        currentSortOrder = order;
+        applyFilters();
     }
 }

--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeCoverageUtils.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeCoverageUtils.java
@@ -1,0 +1,72 @@
+package io.github.atunkodev.web.view;
+
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.reqstool.annotations.Requirements;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Pure utility for coverage and reverse-index computation on recipe trees. No Vaadin dependencies.
+ */
+public final class RecipeCoverageUtils {
+
+    private RecipeCoverageUtils() {}
+
+    /**
+     * For each selected composite, recursively collect all descendants via {@code recipeList()}.
+     * The composite itself is NOT marked as covered — only its transitive children are.
+     */
+    @Requirements({"atunko:WEB_0001.15"})
+    public static Set<RecipeInfo> computeCovered(Set<RecipeInfo> selected) {
+        Set<RecipeInfo> covered = new HashSet<>();
+        for (RecipeInfo recipe : selected) {
+            if (recipe.isComposite()) {
+                collectDescendants(recipe, covered, new HashSet<>());
+            }
+        }
+        return covered;
+    }
+
+    private static void collectDescendants(RecipeInfo recipe, Set<RecipeInfo> result, Set<RecipeInfo> visited) {
+        for (RecipeInfo child : recipe.recipeList()) {
+            if (visited.add(child)) {
+                result.add(child);
+                if (child.isComposite()) {
+                    collectDescendants(child, result, visited);
+                }
+            }
+        }
+    }
+
+    /**
+     * Build a reverse index: for each recipe that appears in any composite's {@code recipeList()},
+     * map it to the list of composites that directly contain it.
+     */
+    @Requirements({"atunko:WEB_0001.16"})
+    public static Map<RecipeInfo, List<RecipeInfo>> buildReverseIndex(List<RecipeInfo> allRecipes) {
+        Map<RecipeInfo, List<RecipeInfo>> result = new HashMap<>();
+        for (RecipeInfo recipe : allRecipes) {
+            if (recipe.isComposite()) {
+                collectParentage(recipe, result, new HashSet<>());
+            }
+        }
+        return result;
+    }
+
+    private static void collectParentage(
+            RecipeInfo parent, Map<RecipeInfo, List<RecipeInfo>> result, Set<RecipeInfo> visited) {
+        if (!visited.add(parent)) {
+            return;
+        }
+        for (RecipeInfo child : parent.recipeList()) {
+            result.computeIfAbsent(child, k -> new ArrayList<>()).add(parent);
+            if (child.isComposite()) {
+                collectParentage(child, result, visited);
+            }
+        }
+    }
+}

--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/RunOrderDialog.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/RunOrderDialog.java
@@ -23,10 +23,13 @@ public class RunOrderDialog extends Dialog {
     private final List<RecipeInfo> originalRecipes;
     private final Grid<RecipeInfo> orderGrid = new Grid<>();
     private final Consumer<List<RecipeInfo>> onConfirm;
+    private final Runnable onCancel;
     private boolean flattened = false;
 
-    public RunOrderDialog(Set<RecipeInfo> selected, boolean dryRun, Consumer<List<RecipeInfo>> onConfirm) {
+    public RunOrderDialog(
+            Set<RecipeInfo> selected, boolean dryRun, Consumer<List<RecipeInfo>> onConfirm, Runnable onCancel) {
         this.onConfirm = onConfirm;
+        this.onCancel = onCancel;
         this.originalRecipes = selected.stream()
                 .sorted((a, b) -> a.displayName().compareToIgnoreCase(b.displayName()))
                 .toList();
@@ -78,7 +81,10 @@ public class RunOrderDialog extends Dialog {
         content.setPadding(false);
         add(content);
 
-        Button cancelButton = new Button("Cancel", VaadinIcon.CLOSE.create(), e -> close());
+        Button cancelButton = new Button("Cancel", VaadinIcon.CLOSE.create(), e -> {
+            close();
+            onCancel.run();
+        });
         cancelButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
 
         Button confirmButton = new Button("Confirm", VaadinIcon.CHECK.create(), e -> {

--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/RunOrderDialog.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/RunOrderDialog.java
@@ -1,0 +1,136 @@
+package io.github.atunkodev.web.view;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.reqstool.annotations.Requirements;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+@Requirements({"atunko:WEB_0001.10"})
+public class RunOrderDialog extends Dialog {
+
+    private final List<RecipeInfo> orderedRecipes;
+    private final List<RecipeInfo> originalRecipes;
+    private final Grid<RecipeInfo> orderGrid = new Grid<>();
+    private final Consumer<List<RecipeInfo>> onConfirm;
+    private boolean flattened = false;
+
+    public RunOrderDialog(Set<RecipeInfo> selected, boolean dryRun, Consumer<List<RecipeInfo>> onConfirm) {
+        this.onConfirm = onConfirm;
+        this.originalRecipes = selected.stream()
+                .sorted((a, b) -> a.displayName().compareToIgnoreCase(b.displayName()))
+                .toList();
+        this.orderedRecipes = new ArrayList<>(originalRecipes);
+
+        setHeaderTitle(dryRun ? "Review Dry Run Order" : "Review Execution Order");
+        setWidth("600px");
+        setCloseOnEsc(true);
+        setCloseOnOutsideClick(false);
+
+        orderGrid.setItems(orderedRecipes);
+        orderGrid
+                .addColumn(r -> orderedRecipes.indexOf(r) + 1)
+                .setHeader("#")
+                .setWidth("50px")
+                .setFlexGrow(0);
+        orderGrid.addColumn(RecipeInfo::displayName).setHeader("Recipe");
+        orderGrid
+                .addColumn(r -> r.isComposite() ? "composite" : "leaf")
+                .setHeader("Type")
+                .setWidth("90px");
+        orderGrid.setSelectionMode(Grid.SelectionMode.SINGLE);
+        orderGrid.setWidthFull();
+
+        Button upButton = new Button(VaadinIcon.ARROW_UP.create(), e -> moveSelected(-1));
+        upButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+
+        Button downButton = new Button(VaadinIcon.ARROW_DOWN.create(), e -> moveSelected(1));
+        downButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+
+        Checkbox flattenToggle = new Checkbox("Flatten composites");
+        flattenToggle.addValueChangeListener(e -> {
+            flattened = e.getValue();
+            if (flattened) {
+                orderedRecipes.clear();
+                orderedRecipes.addAll(flatten(originalRecipes));
+            } else {
+                orderedRecipes.clear();
+                orderedRecipes.addAll(originalRecipes);
+            }
+            orderGrid.getDataProvider().refreshAll();
+        });
+
+        HorizontalLayout controls = new HorizontalLayout(upButton, downButton, flattenToggle);
+        controls.setAlignItems(HorizontalLayout.Alignment.CENTER);
+
+        VerticalLayout content = new VerticalLayout(controls, orderGrid);
+        content.setSizeFull();
+        content.setPadding(false);
+        add(content);
+
+        Button cancelButton = new Button("Cancel", VaadinIcon.CLOSE.create(), e -> close());
+        cancelButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+
+        Button confirmButton = new Button("Confirm", VaadinIcon.CHECK.create(), e -> {
+            close();
+            onConfirm.accept(List.copyOf(orderedRecipes));
+        });
+        confirmButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+
+        getFooter().add(cancelButton, confirmButton);
+    }
+
+    private void moveSelected(int direction) {
+        orderGrid.getSelectedItems().stream().findFirst().ifPresent(selected -> {
+            int index = orderedRecipes.indexOf(selected);
+            int newIndex = index + direction;
+            if (newIndex >= 0 && newIndex < orderedRecipes.size()) {
+                orderedRecipes.set(index, orderedRecipes.get(newIndex));
+                orderedRecipes.set(newIndex, selected);
+                orderGrid.getDataProvider().refreshAll();
+                orderGrid.select(selected);
+            }
+        });
+    }
+
+    static List<RecipeInfo> flatten(List<RecipeInfo> recipes) {
+        LinkedHashSet<RecipeInfo> result = new LinkedHashSet<>();
+        for (RecipeInfo recipe : recipes) {
+            flattenRecursive(recipe, result, new java.util.HashSet<>());
+        }
+        return new ArrayList<>(result);
+    }
+
+    private static void flattenRecursive(RecipeInfo recipe, LinkedHashSet<RecipeInfo> result, Set<RecipeInfo> visited) {
+        if (!visited.add(recipe)) {
+            return;
+        }
+        if (recipe.isComposite()) {
+            for (RecipeInfo child : recipe.recipeList()) {
+                flattenRecursive(child, result, visited);
+            }
+        } else {
+            result.add(recipe);
+        }
+    }
+
+    // --- Testability hooks ---
+
+    List<RecipeInfo> getOrderedRecipes() {
+        return List.copyOf(orderedRecipes);
+    }
+
+    boolean isFlattened() {
+        return flattened;
+    }
+}

--- a/atunko-web/src/test/java/io/github/atunkodev/web/WebUiCommandTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/WebUiCommandTest.java
@@ -26,19 +26,19 @@ class WebUiCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001"})
-    void command_canBeInstantiated() {
+    void commandCanBeInstantiated() {
         assertThat(newCommand()).isNotNull();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.3"})
-    void command_defaultPortIs8080() {
+    void commandDefaultPortIs8080() {
         assertThat(newCommand().getPort()).isEqualTo(8080);
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.3"})
-    void command_customPortIsApplied() {
+    void commandCustomPortIsApplied() {
         WebUiCommand command = newCommand();
         new CommandLine(command).parseArgs("--port", "9090");
         assertThat(command.getPort()).isEqualTo(9090);
@@ -46,13 +46,13 @@ class WebUiCommandTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.10"})
-    void command_defaultProjectDirIsCurrent() {
+    void commandDefaultProjectDirIsCurrent() {
         assertThat(newCommand().getProjectDir()).isEqualTo(Path.of("."));
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.11"})
-    void command_customProjectDirIsApplied() {
+    void commandCustomProjectDirIsApplied() {
         WebUiCommand command = newCommand();
         new CommandLine(command).parseArgs("--project-dir", "/some/project");
         assertThat(command.getProjectDir()).isEqualTo(Path.of("/some/project"));

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/DiffDialogTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/DiffDialogTest.java
@@ -1,0 +1,95 @@
+package io.github.atunkodev.web.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.atunkodev.core.engine.FileChange;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DiffDialogTest {
+
+    // --- deduplicateChanges ---
+
+    @Test
+    void deduplicateChangesEmptyListReturnsEmpty() {
+        assertThat(DiffDialog.deduplicateChanges(List.of())).isEmpty();
+    }
+
+    @Test
+    void deduplicateChangesNoDuplicatesPreservesOrder() {
+        FileChange a = new FileChange(Path.of("A.java"), "old", "new");
+        FileChange b = new FileChange(Path.of("B.java"), "old", "new");
+
+        List<FileChange> result = DiffDialog.deduplicateChanges(List.of(a, b));
+
+        assertThat(result).containsExactly(a, b);
+    }
+
+    @Test
+    void deduplicateChangesDuplicatePathKeepsLast() {
+        FileChange first = new FileChange(Path.of("A.java"), "v1", "v2");
+        FileChange second = new FileChange(Path.of("A.java"), "v2", "v3");
+
+        List<FileChange> result = DiffDialog.deduplicateChanges(List.of(first, second));
+
+        assertThat(result).containsExactly(second);
+    }
+
+    @Test
+    void deduplicateChangesMixedDuplicatesAndUnique() {
+        FileChange a1 = new FileChange(Path.of("A.java"), "a1", "a2");
+        FileChange b = new FileChange(Path.of("B.java"), "b1", "b2");
+        FileChange a2 = new FileChange(Path.of("A.java"), "a2", "a3");
+
+        List<FileChange> result = DiffDialog.deduplicateChanges(List.of(a1, b, a2));
+
+        assertThat(result).containsExactly(a2, b);
+    }
+
+    // --- buildUnifiedDiff ---
+
+    @Test
+    void buildUnifiedDiffModifiedFileProducesDiff() {
+        FileChange change = new FileChange(
+                Path.of("src/Hello.java"),
+                "public class Hello {\n    // old\n}\n",
+                "public class Hello {\n    // new\n}\n");
+
+        String diff = DiffDialog.buildUnifiedDiff(change);
+
+        assertThat(diff).contains("--- a/src/Hello.java");
+        assertThat(diff).contains("+++ b/src/Hello.java");
+        assertThat(diff).contains("-    // old");
+        assertThat(diff).contains("+    // new");
+    }
+
+    @Test
+    void buildUnifiedDiffNewFileUsesDevNullAsSource() {
+        FileChange change = new FileChange(Path.of("New.java"), null, "public class New {}");
+
+        String diff = DiffDialog.buildUnifiedDiff(change);
+
+        assertThat(diff).contains("--- /dev/null");
+        assertThat(diff).contains("+++ b/New.java");
+    }
+
+    @Test
+    void buildUnifiedDiffDeletedFileUsesDevNullAsTarget() {
+        FileChange change = new FileChange(Path.of("Old.java"), "public class Old {}", null);
+
+        String diff = DiffDialog.buildUnifiedDiff(change);
+
+        assertThat(diff).contains("--- a/Old.java");
+        assertThat(diff).contains("+++ /dev/null");
+    }
+
+    @Test
+    void buildUnifiedDiffIdenticalContentReturnsEmpty() {
+        FileChange change = new FileChange(Path.of("Same.java"), "same content", "same content");
+
+        String diff = DiffDialog.buildUnifiedDiff(change);
+
+        assertThat(diff).isEmpty();
+    }
+}

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
@@ -96,14 +96,14 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.1"})
-    void noFilter_displaysAllRecipes() {
+    void noFilterDisplaysAllRecipes() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         assertThat(view.getVisibleRecipes()).containsExactlyInAnyOrder(ALPHA, BETA, GAMMA);
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void textSearch_filtersByName() {
+    void textSearchFiltersByName() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.applyTextFilter("Alpha");
         assertThat(view.getVisibleRecipes()).containsExactly(ALPHA);
@@ -111,7 +111,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void textSearch_filtersByDescription() {
+    void textSearchFiltersByDescription() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.applyTextFilter("about spring");
         assertThat(view.getVisibleRecipes()).containsExactly(ALPHA);
@@ -119,7 +119,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void tagFilter_filtersWithOrLogic() {
+    void tagFilterFiltersWithOrLogic() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.applyTagFilter(Set.of("spring"));
         assertThat(view.getVisibleRecipes()).containsExactlyInAnyOrder(ALPHA, BETA);
@@ -127,7 +127,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void textAndTagFilter_composeWithAnd() {
+    void textAndTagFilterComposeWithAnd() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.applyTextFilter("Alpha");
         view.applyTagFilter(Set.of("spring"));
@@ -136,7 +136,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void tagFilter_emptySelection_showsAllRecipes() {
+    void tagFilterEmptySelectionShowsAllRecipes() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.applyTagFilter(Set.of());
         assertThat(view.getVisibleRecipes()).containsExactlyInAnyOrder(ALPHA, BETA, GAMMA);
@@ -144,7 +144,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.4"})
-    void compositeRecipe_isExpandable() {
+    void compositeRecipeIsExpandable() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE, GAMMA));
         TreeGrid<TreeNode> grid = view.getTreeGrid();
         TreeNode compositeNode = new TreeNode(COMPOSITE, COMPOSITE.name());
@@ -155,7 +155,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.5"})
-    void cascadeSelection_checkParent_checksAllChildren() {
+    void cascadeSelectionCheckParentChecksAllChildren() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE));
         view.getCascadeHandler().selectItem(COMPOSITE);
         assertThat(view.getSelectedRecipes()).contains(COMPOSITE, CHILD_1, CHILD_2);
@@ -163,7 +163,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.5"})
-    void cascadeSelection_checkAllChildren_checksParent() {
+    void cascadeSelectionCheckAllChildrenChecksParent() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE));
         view.getCascadeHandler().selectItem(CHILD_1);
         view.getCascadeHandler().selectItem(CHILD_2);
@@ -172,7 +172,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.5"})
-    void cascadeSelection_uncheckOneChild_parentBecomesIndeterminate() {
+    void cascadeSelectionUncheckOneChildParentBecomesIndeterminate() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE));
         view.getCascadeHandler().selectItem(COMPOSITE);
         view.getCascadeHandler().deselectItem(CHILD_1);
@@ -182,7 +182,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.6"})
-    void clickRecipe_updatesDetailPanel() {
+    void clickRecipeUpdatesDetailPanel() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
         view.selectForDetail(ALPHA);
         assertThat(view.getDetailPanelRecipe()).isEqualTo(ALPHA);
@@ -192,14 +192,14 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.7"})
-    void statusBar_noFilter_showsTotalCount() {
+    void statusBarNoFilterShowsTotalCount() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         assertThat(_find(Span.class).stream().map(Span::getText)).contains("Showing 3 recipes");
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.7"})
-    void statusBar_afterFilter_showsFilteredCount() {
+    void statusBarAfterFilterShowsFilteredCount() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.applyTextFilter("Alpha");
         assertThat(_find(Span.class).stream().map(Span::getText)).contains("Showing 1 recipes");
@@ -209,7 +209,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.8"})
-    void detailPanel_initialState_showsEmptyMessage() {
+    void detailPanelInitialStateShowsEmptyMessage() {
         setupView(List.of(ALPHA));
         Span placeholder = _get(Span.class, spec -> spec.withText("Select a recipe to view details"));
         assertThat(placeholder.getText()).isEqualTo("Select a recipe to view details");
@@ -217,7 +217,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.8"})
-    void detailPanel_tagsDisplay_showsAllTags() {
+    void detailPanelTagsDisplayShowsAllTags() {
         RecipeBrowserView view = setupView(List.of(ALPHA));
         view.selectForDetail(ALPHA);
         // ALPHA has tags: java, spring
@@ -227,7 +227,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.8"})
-    void detailPanel_compositeRecipe_displaysChildList() {
+    void detailPanelCompositeRecipeDisplaysChildList() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE));
         view.selectForDetail(COMPOSITE);
         List<String> spanTexts = _find(Span.class).stream().map(Span::getText).toList();
@@ -237,7 +237,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.8"})
-    void detailPanel_nonCompositeRecipe_noChildList() {
+    void detailPanelNonCompositeRecipeNoChildList() {
         RecipeBrowserView view = setupView(List.of(ALPHA));
         view.selectForDetail(ALPHA);
         List<String> spanTexts = _find(Span.class).stream().map(Span::getText).toList();
@@ -248,7 +248,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.9"})
-    void cascadeSelection_deepHierarchy_selectRoot_selectsAllLevels() {
+    void cascadeSelectionDeepHierarchySelectRootSelectsAllLevels() {
         RecipeBrowserView view = setupView(List.of(LEVEL_1));
         view.getCascadeHandler().selectItem(LEVEL_1);
         assertThat(view.getSelectedRecipes()).contains(LEVEL_1, LEVEL_2, LEVEL_3);
@@ -256,7 +256,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.9"})
-    void cascadeSelection_sharedRecipe_appearsUnderTwoParents_selectedOnce() {
+    void cascadeSelectionSharedRecipeAppearsUnderTwoParentsSelectedOnce() {
         RecipeBrowserView view = setupView(List.of(PARENT_A, PARENT_B));
         view.getCascadeHandler().selectItem(SHARED);
         assertThat(view.getSelectedRecipes()).contains(SHARED);
@@ -270,7 +270,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.22"})
-    void selectAll_selectsAllVisibleRecipes() {
+    void selectAllSelectsAllVisibleRecipes() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.selectAllVisible();
         assertThat(view.getSelectedRecipes()).containsExactlyInAnyOrder(ALPHA, BETA, GAMMA);
@@ -278,7 +278,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.23"})
-    void deselectAll_clearsAllSelections() {
+    void deselectAllClearsAllSelections() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
         view.selectAllVisible();
         view.deselectAll();
@@ -287,7 +287,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.22"})
-    void selectAll_respectsActiveFilter() {
+    void selectAllRespectsActiveFilter() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.applyTextFilter("Alpha");
         view.selectAllVisible();
@@ -298,7 +298,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.20"})
-    void sortByName_ordersAlphabetically() {
+    void sortByNameOrdersAlphabetically() {
         RecipeBrowserView view = setupView(List.of(GAMMA, ALPHA, BETA));
         view.applySortOrder(SortOrder.NAME);
         List<String> names =
@@ -308,7 +308,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.21"})
-    void sortByTags_groupsByFirstTag() {
+    void sortByTagsGroupsByFirstTag() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.applySortOrder(SortOrder.TAGS);
         List<String> names =
@@ -322,7 +322,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.20"})
-    void sortChange_preservesFilter() {
+    void sortChangePreservesFilter() {
         RecipeBrowserView view = setupView(List.of(GAMMA, ALPHA, BETA));
         view.applyTextFilter("Alpha");
         view.applySortOrder(SortOrder.NAME);
@@ -333,7 +333,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.24"})
-    void coverageIndicator_selectAll_childrenAreCovered() {
+    void coverageIndicatorSelectAllChildrenAreCovered() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE, GAMMA));
         view.selectAllVisible();
         assertThat(view.getCoveredRecipes()).contains(CHILD_1, CHILD_2);
@@ -341,7 +341,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.25"})
-    void coverageIndicator_deselectAll_noCoveredRecipes() {
+    void coverageIndicatorDeselectAllNoCoveredRecipes() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE, GAMMA));
         view.selectAllVisible();
         view.deselectAll();
@@ -350,7 +350,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.24"})
-    void coverageIndicator_compositeItselfNotCovered() {
+    void coverageIndicatorCompositeItselfNotCovered() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE));
         view.selectAllVisible();
         assertThat(view.getCoveredRecipes()).doesNotContain(COMPOSITE);
@@ -360,7 +360,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.26"})
-    void detailPanel_includedRecipe_showsIncludedInSection() {
+    void detailPanelIncludedRecipeShowsIncludedInSection() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE));
         view.selectForDetail(CHILD_1);
         List<String> texts = _find(Span.class).stream().map(Span::getText).toList();
@@ -369,7 +369,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.27"})
-    void detailPanel_notIncludedRecipe_noIncludedInSection() {
+    void detailPanelNotIncludedRecipeNoIncludedInSection() {
         RecipeBrowserView view = setupView(List.of(ALPHA, COMPOSITE));
         view.selectForDetail(ALPHA);
         List<String> texts = _find(Span.class).stream().map(Span::getText).toList();
@@ -378,7 +378,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.26"})
-    void detailPanel_sharedRecipe_showsMultipleParents() {
+    void detailPanelSharedRecipeShowsMultipleParents() {
         RecipeBrowserView view = setupView(List.of(PARENT_A, PARENT_B));
         view.selectForDetail(SHARED);
         List<String> texts = _find(Span.class).stream().map(Span::getText).toList();
@@ -389,7 +389,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.17"})
-    void applyRunConfig_selectsMatchingRecipes() {
+    void applyRunConfigSelectsMatchingRecipes() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         RunConfig config = new RunConfig(List.of(new RecipeEntry("org.test.Alpha"), new RecipeEntry("org.test.Gamma")));
         view.applyRunConfig(config);
@@ -398,7 +398,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.18"})
-    void applyRunConfig_ignoresUnknownRecipes() {
+    void applyRunConfigIgnoresUnknownRecipes() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
         RunConfig config =
                 new RunConfig(List.of(new RecipeEntry("org.test.Alpha"), new RecipeEntry("org.test.NonExistent")));
@@ -408,7 +408,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.19"})
-    void applyRunConfig_resolvesChildRecipeName() {
+    void applyRunConfigResolvesChildRecipeName() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE));
         RunConfig config = new RunConfig(List.of(new RecipeEntry("org.test.Child1")));
         view.applyRunConfig(config);
@@ -417,7 +417,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.17"})
-    void applyRunConfig_clearsExistingSelectionFirst() {
+    void applyRunConfigClearsExistingSelectionFirst() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         view.getCascadeHandler().selectItem(BETA);
         RunConfig config = new RunConfig(List.of(new RecipeEntry("org.test.Alpha")));
@@ -429,21 +429,21 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.13"})
-    void dryRunButton_isPresent() {
+    void dryRunButtonIsPresent() {
         RecipeBrowserView view = setupView(List.of(ALPHA));
         assertThat(view.getDryRunButton().getText()).isEqualTo("Dry Run");
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.13"})
-    void executeButton_isPresent() {
+    void executeButtonIsPresent() {
         RecipeBrowserView view = setupView(List.of(ALPHA));
         assertThat(view.getExecuteButton().getText()).isEqualTo("Execute");
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.13"})
-    void runRecipes_noServicesInitialised_doesNotThrow() {
+    void runRecipesNoServicesInitialisedDoesNotThrow() {
         RecipeBrowserView view = setupView(List.of(ALPHA));
         view.getCascadeHandler().selectItem(ALPHA);
         // AppServices not initialised — should be a no-op, not throw
@@ -452,7 +452,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.13"})
-    void runRecipes_noSelection_doesNotThrow() {
+    void runRecipesNoSelectionDoesNotThrow() {
         RecipeExecutionEngine engine = new RecipeExecutionEngine(null);
         AppServices.init(engine, new ProjectSourceParser(), new ChangeApplier());
         SessionHolder.init(Path.of("."), new ProjectInfo(List.of(), List.of(Path.of("."))));
@@ -463,7 +463,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.13"})
-    void runRecipes_dryRun_doesNotApplyChanges() {
+    void runRecipesDryRunDoesNotApplyChanges() {
         List<FileChange>[] appliedChanges = new List[] {null};
         ChangeApplier trackingApplier = new ChangeApplier() {
             @Override
@@ -501,7 +501,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.22"})
-    void clickSelectAllButton_selectsAllVisibleRecipes() {
+    void clickSelectAllButtonSelectsAllVisibleRecipes() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         clearNotifications();
         _click(_get(Button.class, spec -> spec.withText("Select All")));
@@ -510,7 +510,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.23"})
-    void clickDeselectAllButton_clearsAllSelections() {
+    void clickDeselectAllButtonClearsAllSelections() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
         view.selectAllVisible();
         _click(_get(Button.class, spec -> spec.withText("Deselect All")));
@@ -521,7 +521,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.17"})
-    void clickSaveButton_noSelection_showsNotification() {
+    void clickSaveButtonNoSelectionShowsNotification() {
         setupView(List.of(ALPHA));
         clearNotifications();
         _click(_get(Button.class, spec -> spec.withText("Save")));
@@ -535,7 +535,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.17"})
-    void clickSaveButton_withSelection_opensDialogAndSavesFile() throws IOException {
+    void clickSaveButtonWithSelectionOpensDialogAndSavesFile() throws IOException {
         SessionHolder.init(tempDir, null);
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
         view.selectAllVisible();
@@ -572,7 +572,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.17"})
-    void saveDialog_emptyName_showsValidationNotification() {
+    void saveDialogEmptyNameShowsValidationNotification() {
         RecipeBrowserView view = setupView(List.of(ALPHA));
         view.selectAllVisible();
         clearNotifications();
@@ -595,7 +595,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.18"})
-    void clickLoadButton_noRunsDir_showsNotification() {
+    void clickLoadButtonNoRunsDirShowsNotification() {
         SessionHolder.init(tempDir, null);
         setupView(List.of(ALPHA));
         clearNotifications();
@@ -605,7 +605,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.18"})
-    void clickLoadButton_emptyRunsDir_showsNotification() throws IOException {
+    void clickLoadButtonEmptyRunsDirShowsNotification() throws IOException {
         SessionHolder.init(tempDir, null);
         Files.createDirectories(tempDir.resolve("atunko/runs"));
         setupView(List.of(ALPHA));
@@ -618,7 +618,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void searchField_setValue_filtersRecipes() {
+    void searchFieldSetValueFiltersRecipes() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         _setValue(_get(TextField.class, spec -> spec.withPlaceholder("Search recipes...")), "Alpha");
         assertThat(view.getVisibleRecipes()).containsExactly(ALPHA);
@@ -629,7 +629,7 @@ class RecipeBrowserViewTest {
     @Test
     @SVCs({"atunko:SVC_WEB_0001.20"})
     @SuppressWarnings("unchecked")
-    void sortDropdown_setValue_reordersRecipes() {
+    void sortDropdownSetValueReordersRecipes() {
         RecipeBrowserView view = setupView(List.of(GAMMA, ALPHA, BETA));
         // Find the sort select and change its value via Karibu
         List<Select> selects = _find(Select.class);
@@ -649,7 +649,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.13"})
-    void clickDryRunButton_noSelection_showsNotification() {
+    void clickDryRunButtonNoSelectionShowsNotification() {
         RecipeExecutionEngine engine = new RecipeExecutionEngine(null);
         AppServices.init(engine, new ProjectSourceParser(), new ChangeApplier());
         SessionHolder.init(Path.of("."), new ProjectInfo(List.of(), List.of(Path.of("."))));
@@ -661,7 +661,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.13"})
-    void clickExecuteButton_noSelection_showsNotification() {
+    void clickExecuteButtonNoSelectionShowsNotification() {
         RecipeExecutionEngine engine = new RecipeExecutionEngine(null);
         AppServices.init(engine, new ProjectSourceParser(), new ChangeApplier());
         SessionHolder.init(Path.of("."), new ProjectInfo(List.of(), List.of(Path.of("."))));
@@ -675,7 +675,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.14"})
-    void runOrderDialog_flattenCheckbox_expandsComposites() {
+    void runOrderDialogFlattenCheckboxExpandsComposites() {
         List<RecipeInfo> confirmed = new java.util.ArrayList<>();
         RunOrderDialog dialog = new RunOrderDialog(Set.of(COMPOSITE), true, confirmed::addAll);
 
@@ -692,7 +692,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.14"})
-    void runOrderDialog_unflatten_restoresOriginal() {
+    void runOrderDialogUnflattenRestoresOriginal() {
         RunOrderDialog dialog = new RunOrderDialog(Set.of(COMPOSITE), true, _ -> {});
 
         _setValue(_get(dialog, Checkbox.class), true);
@@ -704,7 +704,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.16"})
-    void runOrderDialog_confirmButton_invokesCallback() {
+    void runOrderDialogConfirmButtonInvokesCallback() {
         List<RecipeInfo> confirmed = new java.util.ArrayList<>();
         RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, confirmed::addAll);
 
@@ -715,7 +715,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.16"})
-    void runOrderDialog_cancelButton_doesNotInvokeCallback() {
+    void runOrderDialogCancelButtonDoesNotInvokeCallback() {
         List<RecipeInfo> confirmed = new java.util.ArrayList<>();
         RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA), true, confirmed::addAll);
 
@@ -729,7 +729,7 @@ class RecipeBrowserViewTest {
     @Test
     @SVCs({"atunko:SVC_WEB_0001.18"})
     @SuppressWarnings("unchecked")
-    void clickLoadButton_withSavedRun_loadsAndSelectsRecipes() throws IOException {
+    void clickLoadButtonWithSavedRunLoadsAndSelectsRecipes() throws IOException {
         SessionHolder.init(tempDir, null);
         Path runsDir = tempDir.resolve("atunko/runs");
         Files.createDirectories(runsDir);
@@ -770,7 +770,7 @@ class RecipeBrowserViewTest {
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
     @SuppressWarnings("unchecked")
-    void tagFilter_setValue_filtersRecipesByTag() {
+    void tagFilterSetValueFiltersRecipesByTag() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
         MultiSelectComboBox<String> tagCombo = _get(MultiSelectComboBox.class);
         _setValue(tagCombo, Set.of("spring"));
@@ -782,7 +782,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.6"})
-    void gridSelection_selectRow_updatesDetailPanel() {
+    void gridSelectionSelectRowUpdatesDetailPanel() {
         RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
         TreeGrid<TreeNode> grid = view.getTreeGrid();
 
@@ -805,7 +805,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.6"})
-    void gridSelection_selectCompositeRow_showsChildList() {
+    void gridSelectionSelectCompositeRowShowsChildList() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE));
         TreeGrid<TreeNode> grid = view.getTreeGrid();
 
@@ -826,7 +826,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.17"})
-    void saveDialog_cancelButton_dismissesDialogNoFileCreated() {
+    void saveDialogCancelButtonDismissesDialogNoFileCreated() {
         SessionHolder.init(tempDir, null);
         RecipeBrowserView view = setupView(List.of(ALPHA));
         view.selectAllVisible();
@@ -843,7 +843,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.18"})
-    void loadDialog_cancelButton_doesNotChangeSelection() throws IOException {
+    void loadDialogCancelButtonDoesNotChangeSelection() throws IOException {
         SessionHolder.init(tempDir, null);
         Path runsDir = tempDir.resolve("atunko/runs");
         Files.createDirectories(runsDir);
@@ -863,7 +863,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.18"})
-    void loadDialog_confirmWithoutSelection_showsNotification() throws IOException {
+    void loadDialogConfirmWithoutSelectionShowsNotification() throws IOException {
         SessionHolder.init(tempDir, null);
         Path runsDir = tempDir.resolve("atunko/runs");
         Files.createDirectories(runsDir);
@@ -891,7 +891,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.15"})
-    void runOrderDialog_clickMoveUp_reordersRecipes() {
+    void runOrderDialogClickMoveUpReordersRecipes() {
         RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, _ -> {});
         List<RecipeInfo> initial = dialog.getOrderedRecipes();
         RecipeInfo second = initial.get(1);
@@ -905,7 +905,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.15"})
-    void runOrderDialog_clickMoveDown_reordersRecipes() {
+    void runOrderDialogClickMoveDownReordersRecipes() {
         RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, _ -> {});
         List<RecipeInfo> initial = dialog.getOrderedRecipes();
         RecipeInfo first = initial.get(0);
@@ -923,7 +923,7 @@ class RecipeBrowserViewTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.24"})
-    void coverageSet_afterSelectAll_containsChildrenNotComposite() {
+    void coverageSetAfterSelectAllContainsChildrenNotComposite() {
         RecipeBrowserView view = setupView(List.of(COMPOSITE, GAMMA));
         view.selectAllVisible();
 

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
@@ -677,7 +677,7 @@ class RecipeBrowserViewTest {
     @SVCs({"atunko:SVC_WEB_0001.14"})
     void runOrderDialogFlattenCheckboxExpandsComposites() {
         List<RecipeInfo> confirmed = new java.util.ArrayList<>();
-        RunOrderDialog dialog = new RunOrderDialog(Set.of(COMPOSITE), true, confirmed::addAll);
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(COMPOSITE), true, confirmed::addAll, () -> {});
 
         // Initially has COMPOSITE
         assertThat(dialog.getOrderedRecipes()).containsExactly(COMPOSITE);
@@ -693,7 +693,7 @@ class RecipeBrowserViewTest {
     @Test
     @SVCs({"atunko:SVC_WEB_0001.14"})
     void runOrderDialogUnflattenRestoresOriginal() {
-        RunOrderDialog dialog = new RunOrderDialog(Set.of(COMPOSITE), true, _ -> {});
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(COMPOSITE), true, _ -> {}, () -> {});
 
         _setValue(_get(dialog, Checkbox.class), true);
         _setValue(_get(dialog, Checkbox.class), false);
@@ -706,7 +706,7 @@ class RecipeBrowserViewTest {
     @SVCs({"atunko:SVC_WEB_0001.16"})
     void runOrderDialogConfirmButtonInvokesCallback() {
         List<RecipeInfo> confirmed = new java.util.ArrayList<>();
-        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, confirmed::addAll);
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, confirmed::addAll, () -> {});
 
         _click(_get(dialog, Button.class, spec -> spec.withText("Confirm")));
 
@@ -717,7 +717,7 @@ class RecipeBrowserViewTest {
     @SVCs({"atunko:SVC_WEB_0001.16"})
     void runOrderDialogCancelButtonDoesNotInvokeCallback() {
         List<RecipeInfo> confirmed = new java.util.ArrayList<>();
-        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA), true, confirmed::addAll);
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA), true, confirmed::addAll, () -> {});
 
         _click(_get(dialog, Button.class, spec -> spec.withText("Cancel")));
 
@@ -892,7 +892,7 @@ class RecipeBrowserViewTest {
     @Test
     @SVCs({"atunko:SVC_WEB_0001.15"})
     void runOrderDialogClickMoveUpReordersRecipes() {
-        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, _ -> {});
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, _ -> {}, () -> {});
         List<RecipeInfo> initial = dialog.getOrderedRecipes();
         RecipeInfo second = initial.get(1);
 
@@ -906,7 +906,7 @@ class RecipeBrowserViewTest {
     @Test
     @SVCs({"atunko:SVC_WEB_0001.15"})
     void runOrderDialogClickMoveDownReordersRecipes() {
-        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, _ -> {});
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, _ -> {}, () -> {});
         List<RecipeInfo> initial = dialog.getOrderedRecipes();
         RecipeInfo first = initial.get(0);
 

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
@@ -9,6 +9,8 @@ import com.github.mvysny.kaributesting.v10.Routes;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import io.github.atunkodev.core.AppServices;
+import io.github.atunkodev.core.config.RecipeEntry;
+import io.github.atunkodev.core.config.RunConfig;
 import io.github.atunkodev.core.engine.ChangeApplier;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
@@ -17,6 +19,7 @@ import io.github.atunkodev.core.project.ProjectInfo;
 import io.github.atunkodev.core.project.ProjectSourceParser;
 import io.github.atunkodev.core.project.SessionHolder;
 import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.atunkodev.core.recipe.SortOrder;
 import io.github.atunkodev.web.RecipeHolder;
 import io.github.reqstool.annotations.SVCs;
 import java.nio.file.Path;
@@ -245,6 +248,165 @@ class RecipeBrowserViewTest {
         long count =
                 view.getSelectedRecipes().stream().filter(r -> r.equals(SHARED)).count();
         assertThat(count).isEqualTo(1);
+    }
+
+    // --- Bulk select/deselect (SVC_WEB_0001.22, SVC_WEB_0001.23) ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.22"})
+    void selectAll_selectsAllVisibleRecipes() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
+        view.selectAllVisible();
+        assertThat(view.getSelectedRecipes()).containsExactlyInAnyOrder(ALPHA, BETA, GAMMA);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.23"})
+    void deselectAll_clearsAllSelections() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
+        view.selectAllVisible();
+        view.deselectAll();
+        assertThat(view.getSelectedRecipes()).isEmpty();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.22"})
+    void selectAll_respectsActiveFilter() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
+        view.applyTextFilter("Alpha");
+        view.selectAllVisible();
+        assertThat(view.getSelectedRecipes()).containsExactly(ALPHA);
+    }
+
+    // --- Sorting (SVC_WEB_0001.20, SVC_WEB_0001.21) ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.20"})
+    void sortByName_ordersAlphabetically() {
+        RecipeBrowserView view = setupView(List.of(GAMMA, ALPHA, BETA));
+        view.applySortOrder(SortOrder.NAME);
+        List<String> names =
+                view.getVisibleRecipes().stream().map(RecipeInfo::name).toList();
+        assertThat(names).containsExactly("org.test.Alpha", "org.test.Beta", "org.test.Gamma");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.21"})
+    void sortByTags_groupsByFirstTag() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
+        view.applySortOrder(SortOrder.TAGS);
+        List<String> names =
+                view.getVisibleRecipes().stream().map(RecipeInfo::name).toList();
+        // ALPHA tags: java, spring → first tag min = "java"
+        // BETA tags: spring → first tag = "spring"
+        // GAMMA tags: java → first tag = "java"
+        // Sorted: java group (ALPHA, GAMMA by name), then spring group (BETA)
+        assertThat(names).containsExactly("org.test.Alpha", "org.test.Gamma", "org.test.Beta");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.20"})
+    void sortChange_preservesFilter() {
+        RecipeBrowserView view = setupView(List.of(GAMMA, ALPHA, BETA));
+        view.applyTextFilter("Alpha");
+        view.applySortOrder(SortOrder.NAME);
+        assertThat(view.getVisibleRecipes()).containsExactly(ALPHA);
+    }
+
+    // --- Coverage indicators (SVC_WEB_0001.24, SVC_WEB_0001.25) ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.24"})
+    void coverageIndicator_selectAll_childrenAreCovered() {
+        RecipeBrowserView view = setupView(List.of(COMPOSITE, GAMMA));
+        view.selectAllVisible();
+        assertThat(view.getCoveredRecipes()).contains(CHILD_1, CHILD_2);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.25"})
+    void coverageIndicator_deselectAll_noCoveredRecipes() {
+        RecipeBrowserView view = setupView(List.of(COMPOSITE, GAMMA));
+        view.selectAllVisible();
+        view.deselectAll();
+        assertThat(view.getCoveredRecipes()).isEmpty();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.24"})
+    void coverageIndicator_compositeItselfNotCovered() {
+        RecipeBrowserView view = setupView(List.of(COMPOSITE));
+        view.selectAllVisible();
+        assertThat(view.getCoveredRecipes()).doesNotContain(COMPOSITE);
+    }
+
+    // --- Included-in reverse lookup (SVC_WEB_0001.26, SVC_WEB_0001.27) ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.26"})
+    void detailPanel_includedRecipe_showsIncludedInSection() {
+        RecipeBrowserView view = setupView(List.of(COMPOSITE));
+        view.selectForDetail(CHILD_1);
+        List<String> texts = _find(Span.class).stream().map(Span::getText).toList();
+        assertThat(texts).anyMatch(t -> t.startsWith("Included in:") && t.contains("Composite Recipe"));
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.27"})
+    void detailPanel_notIncludedRecipe_noIncludedInSection() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, COMPOSITE));
+        view.selectForDetail(ALPHA);
+        List<String> texts = _find(Span.class).stream().map(Span::getText).toList();
+        assertThat(texts).noneMatch(t -> t.startsWith("Included in:"));
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.26"})
+    void detailPanel_sharedRecipe_showsMultipleParents() {
+        RecipeBrowserView view = setupView(List.of(PARENT_A, PARENT_B));
+        view.selectForDetail(SHARED);
+        List<String> texts = _find(Span.class).stream().map(Span::getText).toList();
+        assertThat(texts).anyMatch(t -> t.startsWith("Included in:") && t.contains("ParentA") && t.contains("ParentB"));
+    }
+
+    // --- Save/Load run config (SVC_WEB_0001.17, SVC_WEB_0001.18, SVC_WEB_0001.19) ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.17"})
+    void applyRunConfig_selectsMatchingRecipes() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
+        RunConfig config = new RunConfig(List.of(new RecipeEntry("org.test.Alpha"), new RecipeEntry("org.test.Gamma")));
+        view.applyRunConfig(config);
+        assertThat(view.getSelectedRecipes()).containsExactlyInAnyOrder(ALPHA, GAMMA);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.18"})
+    void applyRunConfig_ignoresUnknownRecipes() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
+        RunConfig config =
+                new RunConfig(List.of(new RecipeEntry("org.test.Alpha"), new RecipeEntry("org.test.NonExistent")));
+        view.applyRunConfig(config);
+        assertThat(view.getSelectedRecipes()).containsExactly(ALPHA);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.19"})
+    void applyRunConfig_resolvesChildRecipeName() {
+        RecipeBrowserView view = setupView(List.of(COMPOSITE));
+        RunConfig config = new RunConfig(List.of(new RecipeEntry("org.test.Child1")));
+        view.applyRunConfig(config);
+        assertThat(view.getSelectedRecipes()).contains(CHILD_1);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.17"})
+    void applyRunConfig_clearsExistingSelectionFirst() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
+        view.getCascadeHandler().selectItem(BETA);
+        RunConfig config = new RunConfig(List.of(new RecipeEntry("org.test.Alpha")));
+        view.applyRunConfig(config);
+        assertThat(view.getSelectedRecipes()).containsExactly(ALPHA);
     }
 
     // --- Dry Run / Execute buttons (SVC_WEB_0001.13) ---

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
@@ -1,16 +1,27 @@
 package io.github.atunkodev.web.view;
 
+import static com.github.mvysny.kaributesting.v10.LocatorJ._click;
 import static com.github.mvysny.kaributesting.v10.LocatorJ._find;
 import static com.github.mvysny.kaributesting.v10.LocatorJ._get;
+import static com.github.mvysny.kaributesting.v10.LocatorJ._setValue;
+import static com.github.mvysny.kaributesting.v10.NotificationsKt.clearNotifications;
+import static com.github.mvysny.kaributesting.v10.NotificationsKt.expectNotifications;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.mvysny.kaributesting.v10.MockVaadin;
 import com.github.mvysny.kaributesting.v10.Routes;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import io.github.atunkodev.core.AppServices;
 import io.github.atunkodev.core.config.RecipeEntry;
 import io.github.atunkodev.core.config.RunConfig;
+import io.github.atunkodev.core.config.RunConfigService;
 import io.github.atunkodev.core.engine.ChangeApplier;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
@@ -22,12 +33,15 @@ import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.core.recipe.SortOrder;
 import io.github.atunkodev.web.RecipeHolder;
 import io.github.reqstool.annotations.SVCs;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class RecipeBrowserViewTest {
 
@@ -475,5 +489,334 @@ class RecipeBrowserViewTest {
         view.runRecipes(true);
 
         assertThat(appliedChanges[0]).isNull();
+    }
+
+    // ==========================================================================
+    // Karibu UI interaction tests — buttons, dialogs, notifications, form input
+    // ==========================================================================
+
+    // --- Button click: Select All / Deselect All ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.22"})
+    void clickSelectAllButton_selectsAllVisibleRecipes() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
+        clearNotifications();
+        _click(_get(Button.class, spec -> spec.withText("Select All")));
+        assertThat(view.getSelectedRecipes()).containsExactlyInAnyOrder(ALPHA, BETA, GAMMA);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.23"})
+    void clickDeselectAllButton_clearsAllSelections() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
+        view.selectAllVisible();
+        _click(_get(Button.class, spec -> spec.withText("Deselect All")));
+        assertThat(view.getSelectedRecipes()).isEmpty();
+    }
+
+    // --- Button click: Save with no selection → notification ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.17"})
+    void clickSaveButton_noSelection_showsNotification() {
+        setupView(List.of(ALPHA));
+        clearNotifications();
+        _click(_get(Button.class, spec -> spec.withText("Save")));
+        expectNotifications("No recipes selected");
+    }
+
+    // --- Button click: Save dialog flow with @TempDir ---
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.17"})
+    void clickSaveButton_withSelection_opensDialogAndSavesFile() throws IOException {
+        SessionHolder.init(tempDir, null);
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
+        view.selectAllVisible();
+        clearNotifications();
+
+        // Click Save button → opens save dialog
+        _click(_get(Button.class, spec -> spec.withText("Save")));
+
+        // Fill in the name field inside the dialog
+        _setValue(_get(TextField.class, spec -> spec.withLabel("Name")), "my-test-config");
+
+        // Click the Save button inside the dialog (different from the status bar Save)
+        List<Button> saveButtons = _find(Button.class, spec -> spec.withText("Save"));
+        // The dialog Save button is the second one (first is status bar)
+        Button dialogSaveButton = saveButtons.stream()
+                .filter(b -> b.getParent().isPresent()
+                        && b.getParent().get().getParent().isPresent())
+                .reduce((first, second) -> second)
+                .orElseThrow();
+        _click(dialogSaveButton);
+
+        // Verify file was created
+        Path savedFile = tempDir.resolve("atunko/runs/my-test-config.yaml");
+        assertThat(savedFile).exists();
+
+        // Verify notification
+        expectNotifications("Saved: my-test-config.yaml");
+
+        // Verify file content round-trips
+        RunConfigService service = new RunConfigService();
+        RunConfig loaded = service.load(savedFile);
+        assertThat(loaded.recipes()).hasSize(2);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.17"})
+    void saveDialog_emptyName_showsValidationNotification() {
+        RecipeBrowserView view = setupView(List.of(ALPHA));
+        view.selectAllVisible();
+        clearNotifications();
+
+        _click(_get(Button.class, spec -> spec.withText("Save")));
+
+        // Leave name field empty (default) and click dialog Save
+        List<Button> saveButtons = _find(Button.class, spec -> spec.withText("Save"));
+        Button dialogSaveButton = saveButtons.stream()
+                .filter(b -> b.getParent().isPresent()
+                        && b.getParent().get().getParent().isPresent())
+                .reduce((first, second) -> second)
+                .orElseThrow();
+        _click(dialogSaveButton);
+
+        expectNotifications("Name is required");
+    }
+
+    // --- Button click: Load with no runs dir → notification ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.18"})
+    void clickLoadButton_noRunsDir_showsNotification() {
+        SessionHolder.init(tempDir, null);
+        setupView(List.of(ALPHA));
+        clearNotifications();
+        _click(_get(Button.class, spec -> spec.withText("Load")));
+        expectNotifications("No saved runs found");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.18"})
+    void clickLoadButton_emptyRunsDir_showsNotification() throws IOException {
+        SessionHolder.init(tempDir, null);
+        Files.createDirectories(tempDir.resolve("atunko/runs"));
+        setupView(List.of(ALPHA));
+        clearNotifications();
+        _click(_get(Button.class, spec -> spec.withText("Load")));
+        expectNotifications("No saved runs found");
+    }
+
+    // --- Form input: search field via _setValue ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.2"})
+    void searchField_setValue_filtersRecipes() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
+        _setValue(_get(TextField.class, spec -> spec.withPlaceholder("Search recipes...")), "Alpha");
+        assertThat(view.getVisibleRecipes()).containsExactly(ALPHA);
+    }
+
+    // --- Form input: sort dropdown via _setValue ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.20"})
+    @SuppressWarnings("unchecked")
+    void sortDropdown_setValue_reordersRecipes() {
+        RecipeBrowserView view = setupView(List.of(GAMMA, ALPHA, BETA));
+        // Find the sort select and change its value via Karibu
+        List<Select> selects = _find(Select.class);
+        Select<SortOrder> sortSelect = selects.stream()
+                .filter(s -> s.getValue() instanceof SortOrder)
+                .findFirst()
+                .orElseThrow();
+        _setValue(sortSelect, SortOrder.TAGS);
+
+        List<String> names =
+                view.getVisibleRecipes().stream().map(RecipeInfo::name).toList();
+        // ALPHA(java,spring), GAMMA(java), BETA(spring) → java group first, then spring
+        assertThat(names).containsExactly("org.test.Alpha", "org.test.Gamma", "org.test.Beta");
+    }
+
+    // --- Notification: Dry Run with no selection ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.13"})
+    void clickDryRunButton_noSelection_showsNotification() {
+        RecipeExecutionEngine engine = new RecipeExecutionEngine(null);
+        AppServices.init(engine, new ProjectSourceParser(), new ChangeApplier());
+        SessionHolder.init(Path.of("."), new ProjectInfo(List.of(), List.of(Path.of("."))));
+        setupView(List.of(ALPHA));
+        clearNotifications();
+        _click(_get(Button.class, spec -> spec.withText("Dry Run")));
+        expectNotifications("No recipes selected");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.13"})
+    void clickExecuteButton_noSelection_showsNotification() {
+        RecipeExecutionEngine engine = new RecipeExecutionEngine(null);
+        AppServices.init(engine, new ProjectSourceParser(), new ChangeApplier());
+        SessionHolder.init(Path.of("."), new ProjectInfo(List.of(), List.of(Path.of("."))));
+        setupView(List.of(ALPHA));
+        clearNotifications();
+        _click(_get(Button.class, spec -> spec.withText("Execute")));
+        expectNotifications("No recipes selected");
+    }
+
+    // --- RunOrderDialog: button interactions ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.14"})
+    void runOrderDialog_flattenCheckbox_expandsComposites() {
+        List<RecipeInfo> confirmed = new java.util.ArrayList<>();
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(COMPOSITE), true, confirmed::addAll);
+
+        // Initially has COMPOSITE
+        assertThat(dialog.getOrderedRecipes()).containsExactly(COMPOSITE);
+
+        // Toggle flatten via Karibu
+        _setValue(_get(dialog, Checkbox.class), true);
+
+        // Now should contain the leaf children
+        assertThat(dialog.getOrderedRecipes()).containsExactly(CHILD_1, CHILD_2);
+        assertThat(dialog.isFlattened()).isTrue();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.14"})
+    void runOrderDialog_unflatten_restoresOriginal() {
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(COMPOSITE), true, _ -> {});
+
+        _setValue(_get(dialog, Checkbox.class), true);
+        _setValue(_get(dialog, Checkbox.class), false);
+
+        assertThat(dialog.getOrderedRecipes()).containsExactly(COMPOSITE);
+        assertThat(dialog.isFlattened()).isFalse();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.16"})
+    void runOrderDialog_confirmButton_invokesCallback() {
+        List<RecipeInfo> confirmed = new java.util.ArrayList<>();
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, confirmed::addAll);
+
+        _click(_get(dialog, Button.class, spec -> spec.withText("Confirm")));
+
+        assertThat(confirmed).hasSize(2);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.16"})
+    void runOrderDialog_cancelButton_doesNotInvokeCallback() {
+        List<RecipeInfo> confirmed = new java.util.ArrayList<>();
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA), true, confirmed::addAll);
+
+        _click(_get(dialog, Button.class, spec -> spec.withText("Cancel")));
+
+        assertThat(confirmed).isEmpty();
+    }
+
+    // --- Load dialog flow: pick a file and confirm ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.18"})
+    @SuppressWarnings("unchecked")
+    void clickLoadButton_withSavedRun_loadsAndSelectsRecipes() throws IOException {
+        SessionHolder.init(tempDir, null);
+        Path runsDir = tempDir.resolve("atunko/runs");
+        Files.createDirectories(runsDir);
+
+        // Write a run config with ALPHA
+        RunConfigService service = new RunConfigService();
+        service.save(new RunConfig(List.of(new RecipeEntry("org.test.Alpha"))), runsDir.resolve("saved.yaml"));
+
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
+        clearNotifications();
+
+        // Click Load → opens picker dialog
+        _click(_get(Button.class, spec -> spec.withText("Load")));
+
+        // Select the file in the picker — use style filter to find the dialog's Select (width:100%)
+        List<Select> selects = _find(Select.class);
+        Select<Path> fileSelect = selects.stream()
+                .filter(s -> !(s.getValue() instanceof SortOrder))
+                .findFirst()
+                .orElseThrow();
+        _setValue(fileSelect, runsDir.resolve("saved.yaml"));
+
+        // Click the Load button inside the dialog
+        List<Button> loadButtons = _find(Button.class, spec -> spec.withText("Load"));
+        Button dialogLoadButton = loadButtons.stream()
+                .filter(b -> b.getParent().isPresent()
+                        && b.getParent().get().getParent().isPresent())
+                .reduce((first, second) -> second)
+                .orElseThrow();
+        _click(dialogLoadButton);
+
+        expectNotifications("Loaded: saved");
+        assertThat(view.getSelectedRecipes()).containsExactly(ALPHA);
+    }
+
+    // --- Form input: tag filter via _setValue on MultiSelectComboBox ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.2"})
+    @SuppressWarnings("unchecked")
+    void tagFilter_setValue_filtersRecipesByTag() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA, GAMMA));
+        MultiSelectComboBox<String> tagCombo = _get(MultiSelectComboBox.class);
+        _setValue(tagCombo, Set.of("spring"));
+        // ALPHA has spring + java, BETA has spring, GAMMA has only java
+        assertThat(view.getVisibleRecipes()).containsExactlyInAnyOrder(ALPHA, BETA);
+    }
+
+    // --- Grid selection: select row via UI, verify detail panel ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.6"})
+    void gridSelection_selectRow_updatesDetailPanel() {
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
+        TreeGrid<TreeNode> grid = view.getTreeGrid();
+
+        // Find actual node from grid's data — must match the grid's own TreeNode instance
+        TreeNode alphaNode = grid.getSelectedItems().isEmpty()
+                ? grid.getTreeData().getRootItems().stream()
+                        .filter(n -> n.recipe().equals(ALPHA))
+                        .findFirst()
+                        .orElseThrow()
+                : null;
+        grid.select(alphaNode);
+
+        // The selection listener should update the detail panel
+        assertThat(view.getDetailPanelRecipe()).isEqualTo(ALPHA);
+        // Recipe name is in H3, tags in Span
+        assertThat(_find(H3.class).stream().map(H3::getText).toList()).anyMatch(t -> t.contains("Alpha Recipe"));
+        assertThat(_find(Span.class).stream().map(Span::getText).toList())
+                .anyMatch(t -> t.startsWith("Tags:") && t.contains("spring"));
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.6"})
+    void gridSelection_selectCompositeRow_showsChildList() {
+        RecipeBrowserView view = setupView(List.of(COMPOSITE));
+        TreeGrid<TreeNode> grid = view.getTreeGrid();
+
+        TreeNode compositeNode = grid.getTreeData().getRootItems().stream()
+                .filter(n -> n.recipe().equals(COMPOSITE))
+                .findFirst()
+                .orElseThrow();
+        grid.select(compositeNode);
+
+        assertThat(view.getDetailPanelRecipe()).isEqualTo(COMPOSITE);
+        assertThat(_find(H3.class).stream().map(H3::getText).toList()).anyMatch(t -> t.contains("Composite Recipe"));
+        List<String> spanTexts = _find(Span.class).stream().map(Span::getText).toList();
+        assertThat(spanTexts).anyMatch(t -> t.contains("Child One"));
+        assertThat(spanTexts).anyMatch(t -> t.contains("Child Two"));
     }
 }

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
@@ -13,8 +13,10 @@ import com.github.mvysny.kaributesting.v10.Routes;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.treegrid.TreeGrid;
@@ -818,5 +820,114 @@ class RecipeBrowserViewTest {
         List<String> spanTexts = _find(Span.class).stream().map(Span::getText).toList();
         assertThat(spanTexts).anyMatch(t -> t.contains("Child One"));
         assertThat(spanTexts).anyMatch(t -> t.contains("Child Two"));
+    }
+
+    // --- Dialog cancel buttons ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.17"})
+    void saveDialog_cancelButton_dismissesDialogNoFileCreated() {
+        SessionHolder.init(tempDir, null);
+        RecipeBrowserView view = setupView(List.of(ALPHA));
+        view.selectAllVisible();
+        clearNotifications();
+
+        _click(_get(Button.class, spec -> spec.withText("Save")));
+
+        // Fill name but click Cancel
+        _setValue(_get(TextField.class, spec -> spec.withLabel("Name")), "should-not-save");
+        _click(_get(Button.class, spec -> spec.withText("Cancel")));
+
+        assertThat(tempDir.resolve("atunko/runs/should-not-save.yaml")).doesNotExist();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.18"})
+    void loadDialog_cancelButton_doesNotChangeSelection() throws IOException {
+        SessionHolder.init(tempDir, null);
+        Path runsDir = tempDir.resolve("atunko/runs");
+        Files.createDirectories(runsDir);
+        new RunConfigService()
+                .save(new RunConfig(List.of(new RecipeEntry("org.test.Alpha"))), runsDir.resolve("test.yaml"));
+
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
+        clearNotifications();
+
+        _click(_get(Button.class, spec -> spec.withText("Load")));
+        _click(_get(Button.class, spec -> spec.withText("Cancel")));
+
+        assertThat(view.getSelectedRecipes()).isEmpty();
+    }
+
+    // --- Load dialog: confirm without selecting a file ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.18"})
+    void loadDialog_confirmWithoutSelection_showsNotification() throws IOException {
+        SessionHolder.init(tempDir, null);
+        Path runsDir = tempDir.resolve("atunko/runs");
+        Files.createDirectories(runsDir);
+        new RunConfigService()
+                .save(new RunConfig(List.of(new RecipeEntry("org.test.Alpha"))), runsDir.resolve("test.yaml"));
+
+        setupView(List.of(ALPHA));
+        clearNotifications();
+
+        _click(_get(Button.class, spec -> spec.withText("Load")));
+
+        // Click Load inside dialog without selecting a file first
+        List<Button> loadButtons = _find(Button.class, spec -> spec.withText("Load"));
+        Button dialogLoadButton = loadButtons.stream()
+                .filter(b -> b.getParent().isPresent()
+                        && b.getParent().get().getParent().isPresent())
+                .reduce((first, second) -> second)
+                .orElseThrow();
+        _click(dialogLoadButton);
+
+        expectNotifications("Select a configuration");
+    }
+
+    // --- RunOrderDialog: move up/down via arrow button clicks ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.15"})
+    void runOrderDialog_clickMoveUp_reordersRecipes() {
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, _ -> {});
+        List<RecipeInfo> initial = dialog.getOrderedRecipes();
+        RecipeInfo second = initial.get(1);
+
+        // Select the second recipe in the grid, then click Move Up
+        _get(dialog, Grid.class).select(second);
+        _click(_get(dialog, Button.class, spec -> spec.withIcon(VaadinIcon.ARROW_UP)));
+
+        assertThat(dialog.getOrderedRecipes().get(0)).isEqualTo(second);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.15"})
+    void runOrderDialog_clickMoveDown_reordersRecipes() {
+        RunOrderDialog dialog = new RunOrderDialog(Set.of(ALPHA, BETA), true, _ -> {});
+        List<RecipeInfo> initial = dialog.getOrderedRecipes();
+        RecipeInfo first = initial.get(0);
+
+        // Select the first recipe, then click Move Down
+        _get(dialog, Grid.class).select(first);
+        _click(_get(dialog, Button.class, spec -> spec.withIcon(VaadinIcon.ARROW_DOWN)));
+
+        assertThat(dialog.getOrderedRecipes().get(1)).isEqualTo(first);
+    }
+
+    // --- Coverage badge: verify coveredRecipes drives the badge logic ---
+    // Note: the actual Span rendering inside ComponentHierarchyColumn is not traversable
+    // by Karibu (grid rows are lazily rendered). We verify the data model instead.
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.24"})
+    void coverageSet_afterSelectAll_containsChildrenNotComposite() {
+        RecipeBrowserView view = setupView(List.of(COMPOSITE, GAMMA));
+        view.selectAllVisible();
+
+        assertThat(view.getCoveredRecipes()).contains(CHILD_1, CHILD_2);
+        assertThat(view.getCoveredRecipes()).doesNotContain(COMPOSITE, GAMMA);
     }
 }

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeCoverageUtilsTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeCoverageUtilsTest.java
@@ -1,0 +1,93 @@
+package io.github.atunkodev.web.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.reqstool.annotations.SVCs;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RecipeCoverageUtilsTest {
+
+    private static final RecipeInfo LEAF_A = new RecipeInfo("o.t.A", "Leaf A", "A leaf", Set.of());
+    private static final RecipeInfo LEAF_B = new RecipeInfo("o.t.B", "Leaf B", "B leaf", Set.of());
+    private static final RecipeInfo LEAF_C = new RecipeInfo("o.t.C", "Leaf C", "C leaf", Set.of());
+    private static final RecipeInfo COMPOSITE_1 =
+            new RecipeInfo("o.t.C1", "Composite1", "First composite", Set.of(), List.of(LEAF_A, LEAF_B));
+    private static final RecipeInfo NESTED_COMPOSITE =
+            new RecipeInfo("o.t.NC", "NestedComposite", "Nested", Set.of(), List.of(COMPOSITE_1, LEAF_C));
+
+    // --- computeCovered ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.25"})
+    void computeCovered_singleComposite_returnsChildren() {
+        Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(COMPOSITE_1));
+        assertThat(covered).containsExactlyInAnyOrder(LEAF_A, LEAF_B);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.25"})
+    void computeCovered_nestedComposite_returnsAllDescendants() {
+        Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(NESTED_COMPOSITE));
+        assertThat(covered).containsExactlyInAnyOrder(COMPOSITE_1, LEAF_A, LEAF_B, LEAF_C);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.25"})
+    void computeCovered_noCompositeSelected_returnsEmpty() {
+        Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(LEAF_A));
+        assertThat(covered).isEmpty();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.25"})
+    void computeCovered_compositeItselfNotMarkedAsCovered() {
+        Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(COMPOSITE_1));
+        assertThat(covered).doesNotContain(COMPOSITE_1);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.25"})
+    void computeCovered_emptySelection_returnsEmpty() {
+        Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of());
+        assertThat(covered).isEmpty();
+    }
+
+    // --- buildReverseIndex ---
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.27"})
+    void buildReverseIndex_childInOneComposite_mapsToParent() {
+        Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(COMPOSITE_1));
+        assertThat(index.get(LEAF_A)).containsExactly(COMPOSITE_1);
+        assertThat(index.get(LEAF_B)).containsExactly(COMPOSITE_1);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.27"})
+    void buildReverseIndex_childInMultipleComposites_mapsToAll() {
+        RecipeInfo other = new RecipeInfo("o.t.Other", "Other", "Other composite", Set.of(), List.of(LEAF_A));
+        Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(COMPOSITE_1, other));
+        assertThat(index.get(LEAF_A)).containsExactlyInAnyOrder(COMPOSITE_1, other);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.27"})
+    void buildReverseIndex_noComposites_emptyMap() {
+        Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(LEAF_A, LEAF_B));
+        assertThat(index).isEmpty();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.27"})
+    void buildReverseIndex_nestedComposite_mapsAllLevels() {
+        Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(NESTED_COMPOSITE));
+        assertThat(index.get(COMPOSITE_1)).containsExactly(NESTED_COMPOSITE);
+        assertThat(index.get(LEAF_C)).containsExactly(NESTED_COMPOSITE);
+        assertThat(index.get(LEAF_A)).containsExactly(COMPOSITE_1);
+        assertThat(index.get(LEAF_B)).containsExactly(COMPOSITE_1);
+    }
+}

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeCoverageUtilsTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeCoverageUtilsTest.java
@@ -23,35 +23,35 @@ class RecipeCoverageUtilsTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.25"})
-    void computeCovered_singleComposite_returnsChildren() {
+    void computeCoveredSingleCompositeReturnsChildren() {
         Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(COMPOSITE_1));
         assertThat(covered).containsExactlyInAnyOrder(LEAF_A, LEAF_B);
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.25"})
-    void computeCovered_nestedComposite_returnsAllDescendants() {
+    void computeCoveredNestedCompositeReturnsAllDescendants() {
         Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(NESTED_COMPOSITE));
         assertThat(covered).containsExactlyInAnyOrder(COMPOSITE_1, LEAF_A, LEAF_B, LEAF_C);
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.25"})
-    void computeCovered_noCompositeSelected_returnsEmpty() {
+    void computeCoveredNoCompositeSelectedReturnsEmpty() {
         Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(LEAF_A));
         assertThat(covered).isEmpty();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.25"})
-    void computeCovered_compositeItselfNotMarkedAsCovered() {
+    void computeCoveredCompositeItselfNotMarkedAsCovered() {
         Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(COMPOSITE_1));
         assertThat(covered).doesNotContain(COMPOSITE_1);
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.25"})
-    void computeCovered_emptySelection_returnsEmpty() {
+    void computeCoveredEmptySelectionReturnsEmpty() {
         Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of());
         assertThat(covered).isEmpty();
     }
@@ -60,7 +60,7 @@ class RecipeCoverageUtilsTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.27"})
-    void buildReverseIndex_childInOneComposite_mapsToParent() {
+    void buildReverseIndexChildInOneCompositeMapsToParent() {
         Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(COMPOSITE_1));
         assertThat(index.get(LEAF_A)).containsExactly(COMPOSITE_1);
         assertThat(index.get(LEAF_B)).containsExactly(COMPOSITE_1);
@@ -68,7 +68,7 @@ class RecipeCoverageUtilsTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.27"})
-    void buildReverseIndex_childInMultipleComposites_mapsToAll() {
+    void buildReverseIndexChildInMultipleCompositesMapsToAll() {
         RecipeInfo other = new RecipeInfo("o.t.Other", "Other", "Other composite", Set.of(), List.of(LEAF_A));
         Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(COMPOSITE_1, other));
         assertThat(index.get(LEAF_A)).containsExactlyInAnyOrder(COMPOSITE_1, other);
@@ -76,14 +76,14 @@ class RecipeCoverageUtilsTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.27"})
-    void buildReverseIndex_noComposites_emptyMap() {
+    void buildReverseIndexNoCompositesEmptyMap() {
         Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(LEAF_A, LEAF_B));
         assertThat(index).isEmpty();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.27"})
-    void buildReverseIndex_nestedComposite_mapsAllLevels() {
+    void buildReverseIndexNestedCompositeMapsAllLevels() {
         Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(NESTED_COMPOSITE));
         assertThat(index.get(COMPOSITE_1)).containsExactly(NESTED_COMPOSITE);
         assertThat(index.get(LEAF_C)).containsExactly(NESTED_COMPOSITE);

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeFilterTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeFilterTest.java
@@ -21,47 +21,47 @@ class RecipeFilterTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesText_nullQuery_returnsTrue() {
+    void matchesTextNullQueryReturnsTrue() {
         assertThat(RecipeFilter.matchesText(SPRING, null)).isTrue();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesText_blankQuery_returnsTrue() {
+    void matchesTextBlankQueryReturnsTrue() {
         assertThat(RecipeFilter.matchesText(SPRING, "")).isTrue();
         assertThat(RecipeFilter.matchesText(SPRING, "   ")).isTrue();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesText_caseInsensitive_matches() {
+    void matchesTextCaseInsensitiveMatches() {
         assertThat(RecipeFilter.matchesText(SPRING, "SPRING")).isTrue();
         assertThat(RecipeFilter.matchesText(SPRING, "migrate")).isTrue();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesText_multiWordQuery_requiresAllWords() {
+    void matchesTextMultiWordQueryRequiresAllWords() {
         assertThat(RecipeFilter.matchesText(SPRING, "migrate boot")).isTrue();
         assertThat(RecipeFilter.matchesText(SPRING, "migrate kotlin")).isFalse();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesText_partialWord_matches() {
+    void matchesTextPartialWordMatches() {
         assertThat(RecipeFilter.matchesText(SPRING, "sprin")).isTrue();
         assertThat(RecipeFilter.matchesText(SPRING, "migrat")).isTrue();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesText_noMatch_returnsFalse() {
+    void matchesTextNoMatchReturnsFalse() {
         assertThat(RecipeFilter.matchesText(SPRING, "groovy")).isFalse();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesText_unicodeQuery_matches() {
+    void matchesTextUnicodeQueryMatches() {
         assertThat(RecipeFilter.matchesText(UNICODE, "Café")).isTrue();
         assertThat(RecipeFilter.matchesText(UNICODE, "λ")).isTrue();
     }
@@ -70,31 +70,31 @@ class RecipeFilterTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesTags_nullTags_returnsTrue() {
+    void matchesTagsNullTagsReturnsTrue() {
         assertThat(RecipeFilter.matchesTags(SPRING, null)).isTrue();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesTags_emptyTags_returnsTrue() {
+    void matchesTagsEmptyTagsReturnsTrue() {
         assertThat(RecipeFilter.matchesTags(SPRING, Set.of())).isTrue();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesTags_singleTagMatch_returnsTrue() {
+    void matchesTagsSingleTagMatchReturnsTrue() {
         assertThat(RecipeFilter.matchesTags(SPRING, Set.of("java"))).isTrue();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesTags_singleTagNoMatch_returnsFalse() {
+    void matchesTagsSingleTagNoMatchReturnsFalse() {
         assertThat(RecipeFilter.matchesTags(SPRING, Set.of("kotlin"))).isFalse();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesTags_multipleTagsOrLogic_returnsTrue() {
+    void matchesTagsMultipleTagsOrLogicReturnsTrue() {
         // SPRING has "java" — filter includes "spring" and "java" — should match (OR logic)
         assertThat(RecipeFilter.matchesTags(SPRING, Set.of("spring", "kotlin"))).isTrue();
         // KOTLIN has only "kotlin" — filter includes "java" only — should not match
@@ -103,7 +103,7 @@ class RecipeFilterTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesTags_noTagMatch_returnsFalse() {
+    void matchesTagsNoTagMatchReturnsFalse() {
         assertThat(RecipeFilter.matchesTags(SPRING, Set.of("groovy", "scala"))).isFalse();
     }
 
@@ -111,7 +111,7 @@ class RecipeFilterTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void filter_emptyFilters_returnsAll() {
+    void filterEmptyFiltersReturnsAll() {
         List<RecipeInfo> recipes = List.of(SPRING, KOTLIN, UNICODE);
         assertThat(RecipeFilter.filter(recipes, null, null)).containsExactlyInAnyOrder(SPRING, KOTLIN, UNICODE);
         assertThat(RecipeFilter.filter(recipes, "", Set.of())).containsExactlyInAnyOrder(SPRING, KOTLIN, UNICODE);
@@ -119,7 +119,7 @@ class RecipeFilterTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void filter_noMatches_returnsEmpty() {
+    void filterNoMatchesReturnsEmpty() {
         List<RecipeInfo> recipes = List.of(SPRING, KOTLIN, UNICODE);
         assertThat(RecipeFilter.filter(recipes, "groovy", Set.of())).isEmpty();
         assertThat(RecipeFilter.filter(recipes, "", Set.of("groovy"))).isEmpty();
@@ -127,7 +127,7 @@ class RecipeFilterTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.2"})
-    void matchesText_fullyQualifiedName_matches() {
+    void matchesTextFullyQualifiedNameMatches() {
         assertThat(RecipeFilter.matchesText(SPRING, "o.t.Spring")).isTrue();
         assertThat(RecipeFilter.matchesText(SPRING, "o.t.Kotlin")).isFalse();
     }

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RunOrderDialogTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RunOrderDialogTest.java
@@ -1,0 +1,73 @@
+package io.github.atunkodev.web.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.reqstool.annotations.SVCs;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RunOrderDialogTest {
+
+    private static final RecipeInfo LEAF_A = new RecipeInfo("o.t.A", "Leaf A", "A leaf", Set.of());
+    private static final RecipeInfo LEAF_B = new RecipeInfo("o.t.B", "Leaf B", "B leaf", Set.of());
+    private static final RecipeInfo LEAF_C = new RecipeInfo("o.t.C", "Leaf C", "C leaf", Set.of());
+    private static final RecipeInfo COMPOSITE =
+            new RecipeInfo("o.t.Comp", "Composite", "A composite", Set.of(), List.of(LEAF_A, LEAF_B));
+    private static final RecipeInfo NESTED =
+            new RecipeInfo("o.t.Nested", "Nested", "Nested composite", Set.of(), List.of(COMPOSITE, LEAF_C));
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.15"})
+    void flatten_expandsCompositesRecursively() {
+        List<RecipeInfo> result = RunOrderDialog.flatten(List.of(NESTED));
+        assertThat(result).containsExactly(LEAF_A, LEAF_B, LEAF_C);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.15"})
+    void flatten_deduplicatesSharedRecipes() {
+        RecipeInfo other = new RecipeInfo("o.t.Other", "Other", "Other", Set.of(), List.of(LEAF_A));
+        List<RecipeInfo> result = RunOrderDialog.flatten(List.of(COMPOSITE, other));
+        assertThat(result).containsExactly(LEAF_A, LEAF_B);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.15"})
+    void flatten_leafRecipes_unchanged() {
+        List<RecipeInfo> result = RunOrderDialog.flatten(List.of(LEAF_A, LEAF_B));
+        assertThat(result).containsExactly(LEAF_A, LEAF_B);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.14"})
+    void flatten_emptyList_returnsEmpty() {
+        List<RecipeInfo> result = RunOrderDialog.flatten(List.of());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.16"})
+    void moveUp_swapsWithPrevious() {
+        List<RecipeInfo> input = new java.util.ArrayList<>(List.of(LEAF_A, LEAF_B, LEAF_C));
+        // Simulate swap: move index 1 up
+        int index = 1;
+        RecipeInfo temp = input.get(index - 1);
+        input.set(index - 1, input.get(index));
+        input.set(index, temp);
+        assertThat(input).containsExactly(LEAF_B, LEAF_A, LEAF_C);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.16"})
+    void moveDown_swapsWithNext() {
+        List<RecipeInfo> input = new java.util.ArrayList<>(List.of(LEAF_A, LEAF_B, LEAF_C));
+        // Simulate swap: move index 1 down
+        int index = 1;
+        RecipeInfo temp = input.get(index + 1);
+        input.set(index + 1, input.get(index));
+        input.set(index, temp);
+        assertThat(input).containsExactly(LEAF_A, LEAF_C, LEAF_B);
+    }
+}

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RunOrderDialogTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RunOrderDialogTest.java
@@ -20,14 +20,14 @@ class RunOrderDialogTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.15"})
-    void flatten_expandsCompositesRecursively() {
+    void flattenExpandsCompositesRecursively() {
         List<RecipeInfo> result = RunOrderDialog.flatten(List.of(NESTED));
         assertThat(result).containsExactly(LEAF_A, LEAF_B, LEAF_C);
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.15"})
-    void flatten_deduplicatesSharedRecipes() {
+    void flattenDeduplicatesSharedRecipes() {
         RecipeInfo other = new RecipeInfo("o.t.Other", "Other", "Other", Set.of(), List.of(LEAF_A));
         List<RecipeInfo> result = RunOrderDialog.flatten(List.of(COMPOSITE, other));
         assertThat(result).containsExactly(LEAF_A, LEAF_B);
@@ -35,21 +35,21 @@ class RunOrderDialogTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.15"})
-    void flatten_leafRecipes_unchanged() {
+    void flattenLeafRecipesUnchanged() {
         List<RecipeInfo> result = RunOrderDialog.flatten(List.of(LEAF_A, LEAF_B));
         assertThat(result).containsExactly(LEAF_A, LEAF_B);
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.14"})
-    void flatten_emptyList_returnsEmpty() {
+    void flattenEmptyListReturnsEmpty() {
         List<RecipeInfo> result = RunOrderDialog.flatten(List.of());
         assertThat(result).isEmpty();
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.16"})
-    void moveUp_swapsWithPrevious() {
+    void moveUpSwapsWithPrevious() {
         List<RecipeInfo> input = new java.util.ArrayList<>(List.of(LEAF_A, LEAF_B, LEAF_C));
         // Simulate swap: move index 1 up
         int index = 1;
@@ -61,7 +61,7 @@ class RunOrderDialogTest {
 
     @Test
     @SVCs({"atunko:SVC_WEB_0001.16"})
-    void moveDown_swapsWithNext() {
+    void moveDownSwapsWithNext() {
         List<RecipeInfo> input = new java.util.ArrayList<>(List.of(LEAF_A, LEAF_B, LEAF_C));
         // Simulate swap: move index 1 down
         int index = 1;

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -122,6 +122,84 @@ requirements:
     categories: [interaction-capability]
     revision: 0.1.0
 
+  - id: WEB_0001.10
+    title: Web UI — Run Order Dialog
+    significance: shall
+    description: >-
+      The Web UI shall show a mandatory run order dialog before every recipe execution,
+      with an ordered list of selected recipes, move-up/down controls for reordering,
+      and a flatten-composites toggle that recursively expands composites into leaf recipes
+    references:
+      requirement_ids: ["WEB_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: WEB_0001.11
+    title: Web UI — Save Named Run Configuration
+    significance: shall
+    description: >-
+      The Web UI shall allow saving the current recipe selection as a named run
+      configuration to atunko/runs/<name>.yaml using the core RunConfigService
+    references:
+      requirement_ids: ["WEB_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: WEB_0001.12
+    title: Web UI — Load Named Run Configuration
+    significance: shall
+    description: >-
+      The Web UI shall allow loading a saved run configuration from atunko/runs/*.yaml,
+      resolving recipe names to available recipes and selecting them in the tree grid
+    references:
+      requirement_ids: ["WEB_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: WEB_0001.13
+    title: Web UI — Recipe Sorting
+    significance: shall
+    description: >-
+      The Web UI shall provide a sort-order dropdown allowing the user to sort recipes
+      by name (alphabetical) or by tags (grouped by first tag, then alphabetical)
+    references:
+      requirement_ids: ["WEB_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: WEB_0001.14
+    title: Web UI — Bulk Select and Deselect
+    significance: shall
+    description: >-
+      The Web UI shall provide Select All and Deselect All buttons that respect active
+      filters, selecting or deselecting only the currently visible recipes
+    references:
+      requirement_ids: ["WEB_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: WEB_0001.15
+    title: Web UI — Coverage Indicators
+    significance: shall
+    description: >-
+      The Web UI shall display a visual badge on recipes that are transitively included
+      in a selected composite recipe, indicating they will be executed as part of the composite
+    references:
+      requirement_ids: ["WEB_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: WEB_0001.16
+    title: Web UI — Included-In Reverse Lookup
+    significance: shall
+    description: >-
+      The Web UI detail panel shall show which composite recipes include the selected recipe,
+      displayed as an "Included in: X, Y" section
+    references:
+      requirement_ids: ["WEB_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
   # TUI requirements
   - id: TUI_0001
     title: TUI Launch

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -148,6 +148,146 @@ cases:
       THEN the recipes are run (or previewed) and the resulting file changes are displayed
     revision: "0.1.0"
 
+  - id: SVC_WEB_0001.14
+    requirement_ids: ["WEB_0001.10"]
+    title: Run order dialog — flatten composites
+    verification: automated-test
+    description: |
+      GIVEN a set of selected recipes including composites
+      WHEN the flatten toggle is activated in the run order dialog
+      THEN composite recipes are recursively expanded into their leaf recipes with deduplication
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.15
+    requirement_ids: ["WEB_0001.10"]
+    title: Run order dialog — move up and down
+    verification: automated-test
+    description: |
+      GIVEN selected recipes are displayed in the run order dialog
+      WHEN the user clicks Move Up or Move Down
+      THEN the selected recipe swaps position with its neighbor
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.16
+    requirement_ids: ["WEB_0001.10"]
+    title: Run order dialog — confirm triggers execution
+    verification: automated-test
+    description: |
+      GIVEN the run order dialog is open with ordered recipes
+      WHEN the user clicks Confirm
+      THEN the onConfirm callback is invoked with the current recipe order
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.17
+    requirement_ids: ["WEB_0001.11"]
+    title: Save run configuration — selects matching recipes on load
+    verification: automated-test
+    description: |
+      GIVEN a RunConfig with recipe entries
+      WHEN applyRunConfig is called
+      THEN the matching recipes are selected in the tree grid
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.18
+    requirement_ids: ["WEB_0001.12"]
+    title: Load run configuration — ignores unknown recipes
+    verification: automated-test
+    description: |
+      GIVEN a RunConfig containing recipe names not in the current recipe list
+      WHEN applyRunConfig is called
+      THEN unknown recipes are silently skipped and known recipes are selected
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.19
+    requirement_ids: ["WEB_0001.12"]
+    title: Load run configuration — resolves child recipe names
+    verification: automated-test
+    description: |
+      GIVEN a RunConfig with a recipe name that is a child of a composite
+      WHEN applyRunConfig is called
+      THEN the child recipe is found via recursive lookup and selected
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.20
+    requirement_ids: ["WEB_0001.13"]
+    title: Sort by name orders alphabetically
+    verification: automated-test
+    description: |
+      GIVEN a list of recipes in arbitrary order
+      WHEN sort order is set to NAME
+      THEN recipes are displayed in alphabetical order by fully qualified name
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.21
+    requirement_ids: ["WEB_0001.13"]
+    title: Sort by tags groups by first tag
+    verification: automated-test
+    description: |
+      GIVEN a list of recipes with different tags
+      WHEN sort order is set to TAGS
+      THEN recipes are grouped by their first tag alphabetically, then by name within each group
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.22
+    requirement_ids: ["WEB_0001.14"]
+    title: Select All selects all visible recipes
+    verification: automated-test
+    description: |
+      GIVEN a filtered or unfiltered recipe list
+      WHEN Select All is clicked
+      THEN all currently visible recipes are selected
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.23
+    requirement_ids: ["WEB_0001.14"]
+    title: Deselect All clears all selections
+    verification: automated-test
+    description: |
+      GIVEN one or more recipes are selected
+      WHEN Deselect All is clicked
+      THEN no recipes remain selected
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.24
+    requirement_ids: ["WEB_0001.15"]
+    title: Coverage badge appears on children of selected composite
+    verification: automated-test
+    description: |
+      GIVEN a composite recipe is selected
+      WHEN the tree grid renders
+      THEN child recipes of the composite display a "covered" badge
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.25
+    requirement_ids: ["WEB_0001.15"]
+    title: Coverage badge disappears when composite is deselected
+    verification: automated-test
+    description: |
+      GIVEN a composite recipe was selected (children showing "covered" badge)
+      WHEN the composite is deselected
+      THEN the "covered" badge is removed from all children
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.26
+    requirement_ids: ["WEB_0001.16"]
+    title: Detail panel shows included-in section for child recipes
+    verification: automated-test
+    description: |
+      GIVEN a recipe that is a child of one or more composite recipes
+      WHEN the recipe is selected for detail view
+      THEN the detail panel shows "Included in: X, Y" listing the parent composites
+    revision: "0.1.0"
+
+  - id: SVC_WEB_0001.27
+    requirement_ids: ["WEB_0001.16"]
+    title: Detail panel omits included-in for top-level recipes
+    verification: automated-test
+    description: |
+      GIVEN a recipe that is not a child of any composite
+      WHEN the recipe is selected for detail view
+      THEN the detail panel does not show an "Included in" section
+    revision: "0.1.0"
+
   - id: SVC_CORE_0001
     requirement_ids: ["CORE_0001"]
     title: Discover all recipes from classpath

--- a/gradle/checkstyle/suppressions.xml
+++ b/gradle/checkstyle/suppressions.xml
@@ -7,6 +7,4 @@
     <!-- Exclude generated code -->
     <suppress files="build[/\\]generated[/\\]" checks=".*"/>
 
-    <!-- Allow underscores in test method names (e.g., discoverAll_returnsNonEmptyList) -->
-    <suppress files="[/\\]src[/\\]test[/\\]" checks="MethodName"/>
 </suppressions>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ vaadin = "25.1.0"
 vaadin-boot = "13.6"
 karibu-testing = "2.7.0"
 javadiffutils = "4.12"
+playwright = "1.50.0"
 
 [libraries]
 # OpenRewrite BOM
@@ -71,6 +72,9 @@ karibu-testing = { module = "com.github.mvysny.kaributesting:karibu-testing-v24"
 
 # java-diff-utils
 javadiffutils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref = "javadiffutils" }
+
+# Playwright
+playwright = { module = "com.microsoft.playwright:playwright", version.ref = "playwright" }
 
 # Error Prone
 errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone" }

--- a/openspec/changes/archive/2026-04-07-web-enhancements/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-07-web-enhancements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: change
+state: active

--- a/openspec/changes/archive/2026-04-07-web-enhancements/design.md
+++ b/openspec/changes/archive/2026-04-07-web-enhancements/design.md
@@ -1,0 +1,73 @@
+# Design: Web UI Enhancements
+
+## Key Decisions
+
+1. **Single branch, single PR** — all 6 features on `feat/web-enhancements`, closing
+   #36–#41 together. They touch mostly orthogonal parts of `RecipeBrowserView` and share
+   the `RecipeCoverageUtils` utility.
+
+2. **Shared `RecipeCoverageUtils`** — pure static utility (no Vaadin deps) providing:
+   - `computeCovered(Set<RecipeInfo>)` for coverage badges (#40)
+   - `buildReverseIndex(List<RecipeInfo>)` for included-in lookup (#41)
+   Handles cycles via visited sets, same pattern as `CascadeSelectionHandler`.
+
+3. **Run order dialog is mandatory** — every Dry Run / Execute click shows `RunOrderDialog`
+   first. Current `runRecipes(dryRun)` is split: dialog opening + `executeRecipes(ordered, dryRun)`
+   callback. The dialog receives the selected set, orders alphabetically by default, and
+   returns the user-confirmed ordered list.
+
+4. **Flatten is recursive dedup** — `RunOrderDialog.flatten()` walks `recipeList()` recursively,
+   collects leaves into a `LinkedHashSet` (preserves order, deduplicates).
+
+5. **Named runs via directory convention** — saves to `projectDir/atunko/runs/<name>.yaml`.
+   Load scans `atunko/runs/` for `*.yaml` files, shows picker dialog. No magic default —
+   all runs are named equally.
+
+6. **Richer run config format** — `RunConfig` evolves from flat recipe name list to structured
+   format with `description`, per-recipe `options`, and per-recipe `exclude`:
+   ```yaml
+   version: 1
+   description: Spring Boot 3.5 migration
+   recipes:
+     - name: org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_5
+       options:
+         newVersion: 3.5.0
+       exclude:
+         - org.openrewrite.java.spring.boot3.SomeSubRecipe
+     - name: org.openrewrite.java.migrate.UpgradeToJava21
+   ```
+   Core changes: `RunConfig` record gains `description` field, `recipes` changes from
+   `List<String>` to `List<RecipeEntry>` where
+   `RecipeEntry(String name, Map<String, Object> options, List<String> exclude)`.
+   Both `options` and `exclude` are nullable/optional per entry. `Map<String, Object>` lets
+   Jackson deserialize YAML native types naturally (strings, booleans, integers) without
+   forcing everything through string coercion. Storing composites with excludes (rather
+   than flattening) preserves user intent — bumping the OpenRewrite BOM automatically picks
+   up new sub-recipes without the run config going stale.
+   `RunConfigService` unchanged (Jackson handles the new structure automatically).
+
+7. **JSON Schema for run config** — `run.schema.json` validates the YAML format. Shipped in
+   the project and can be referenced by IDEs for autocomplete.
+   `RunConfigService.load()` validates against the schema before deserializing.
+
+9. **Sort reuses core `SortOrder`** — `SortOrder.NAME` and `SortOrder.TAGS` with their
+   `comparator()` method. Applied in `applyFilters()` after filtering, before tree building.
+
+10. **Bulk select wraps in `inCascadeUpdate`** — prevents N selection listener firings during
+    bulk operation. Iterates `getVisibleRecipes()` (filtered list) for Select All.
+
+11. **Coverage badge via `addComponentHierarchyColumn`** — replaces text hierarchy column
+   with a component renderer. Shows `Span` name + Lumo `badge contrast small` "covered"
+   when `coveredRecipes.contains(node.recipe())`. Recomputed on selection change.
+
+## Implementation Order
+
+Sequential to minimise conflicts in `RecipeBrowserView.java`:
+
+1. `RecipeCoverageUtils` (shared utility, no conflicts)
+2. #41 included-in (touches only `selectForDetail()`)
+3. #40 coverage (touches `buildTreeGrid()` + selection listener)
+4. #36 run order dialog (new class + `runRecipes()` refactor)
+5. #38 sorting (touches `buildSearchBar()` + `applyFilters()`)
+6. #39 bulk select (touches `buildStatusBar()`)
+7. #37 save/load (touches `buildStatusBar()`, new dialogs)

--- a/openspec/changes/archive/2026-04-07-web-enhancements/proposal.md
+++ b/openspec/changes/archive/2026-04-07-web-enhancements/proposal.md
@@ -1,0 +1,52 @@
+# Proposal: Web UI Enhancements — Bulk Select, Sorting, Run Order, Save/Load, Coverage, Included-In
+
+## Why
+
+The Web UI can browse and execute recipes, but lacks workflow features that make it
+productive for real use. Users need to sort and bulk-select recipes efficiently, review
+execution order before running, save/load named configurations, and understand which
+recipes overlap via composite coverage indicators and reverse-lookup.
+
+Issues: atunko-dev/atunko#36, atunko-dev/atunko#37, atunko-dev/atunko#38,
+atunko-dev/atunko#39, atunko-dev/atunko#40, atunko-dev/atunko#41
+
+## What Changes
+
+- **Run order dialog** (#36) — mandatory confirmation dialog before every Dry Run / Execute,
+  showing selected recipes in an ordered grid with move-up/down controls and a "flatten
+  composites" toggle that recursively expands composite recipes into their constituents
+- **Save/load named configs** (#37) — save current recipe selection to
+  `atunko/runs/<name>.yaml`, load from a picker that lists available runs.
+  Reuses core `RunConfigService`.
+- **Sorting** (#38) — `Select<SortOrder>` dropdown to sort recipes by name (alphabetical)
+  or by tags (group by first tag). Reuses core `SortOrder` enum.
+- **Bulk select/deselect** (#39) — Select All (respects active filters) and Deselect All
+  buttons in the status bar
+- **Coverage indicators** (#40) — Lumo "covered" badge on recipes that are already included
+  in a selected composite, preventing redundant selection
+- **Included-in reverse lookup** (#41) — detail panel shows "Included in: X, Y" for recipes
+  that appear in composite recipes' `recipeList()`
+
+## Capabilities
+
+### New Capabilities
+- `web-run-order`: Mandatory run order dialog with reorder and flatten (WEB_0001.10)
+- `web-save-load-config`: Save/load named run configurations (WEB_0001.11, WEB_0001.12)
+- `web-sorting`: Sort recipes by name or tags (WEB_0001.13)
+- `web-bulk-select`: Select all / deselect all visible recipes (WEB_0001.14)
+- `web-coverage-indicators`: Visual badge for recipes covered by selected composites (WEB_0001.15)
+- `web-included-in`: Reverse lookup of composite membership in detail panel (WEB_0001.16)
+
+### Modified Capabilities
+_(none — existing execution and browsing unchanged)_
+
+## Impact
+
+- **New files**: `RunOrderDialog.java`, `RecipeCoverageUtils.java` (shared utility for
+  #40 and #41), plus corresponding test files
+- **Modified files**: `RecipeBrowserView.java` (all 6 features add fields/methods),
+  `RecipeBrowserViewTest.java`, `requirements.yml`, `software_verification_cases.yml`
+- **Reused core**: `SortOrder` (sorting), `RunConfigService` (save/load)
+- **Core changes**: `RunConfig` evolves to structured format with `description` and
+  per-recipe `options`; `RecipeEntry` record added; JSON Schema for validation
+- **No breaking changes**: Existing UI behaviour preserved; run order dialog is additive

--- a/openspec/changes/archive/2026-04-07-web-enhancements/specs/web-enhancements/spec.md
+++ b/openspec/changes/archive/2026-04-07-web-enhancements/specs/web-enhancements/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: WEB_0001.10
+The system SHALL implement WEB_0001.10.
+
+#### Scenario: SVC_WEB_0001.14
+The system SHALL pass SVC_WEB_0001.14.
+
+#### Scenario: SVC_WEB_0001.15
+The system SHALL pass SVC_WEB_0001.15.
+
+#### Scenario: SVC_WEB_0001.16
+The system SHALL pass SVC_WEB_0001.16.
+
+### Requirement: WEB_0001.11
+The system SHALL implement WEB_0001.11.
+
+#### Scenario: SVC_WEB_0001.17
+The system SHALL pass SVC_WEB_0001.17.
+
+### Requirement: WEB_0001.12
+The system SHALL implement WEB_0001.12.
+
+#### Scenario: SVC_WEB_0001.18
+The system SHALL pass SVC_WEB_0001.18.
+
+#### Scenario: SVC_WEB_0001.19
+The system SHALL pass SVC_WEB_0001.19.
+
+### Requirement: WEB_0001.13
+The system SHALL implement WEB_0001.13.
+
+#### Scenario: SVC_WEB_0001.20
+The system SHALL pass SVC_WEB_0001.20.
+
+#### Scenario: SVC_WEB_0001.21
+The system SHALL pass SVC_WEB_0001.21.
+
+### Requirement: WEB_0001.14
+The system SHALL implement WEB_0001.14.
+
+#### Scenario: SVC_WEB_0001.22
+The system SHALL pass SVC_WEB_0001.22.
+
+#### Scenario: SVC_WEB_0001.23
+The system SHALL pass SVC_WEB_0001.23.
+
+### Requirement: WEB_0001.15
+The system SHALL implement WEB_0001.15.
+
+#### Scenario: SVC_WEB_0001.24
+The system SHALL pass SVC_WEB_0001.24.
+
+#### Scenario: SVC_WEB_0001.25
+The system SHALL pass SVC_WEB_0001.25.
+
+### Requirement: WEB_0001.16
+The system SHALL implement WEB_0001.16.
+
+#### Scenario: SVC_WEB_0001.26
+The system SHALL pass SVC_WEB_0001.26.
+
+#### Scenario: SVC_WEB_0001.27
+The system SHALL pass SVC_WEB_0001.27.

--- a/openspec/changes/archive/2026-04-07-web-enhancements/tasks.md
+++ b/openspec/changes/archive/2026-04-07-web-enhancements/tasks.md
@@ -1,0 +1,66 @@
+## 1. Shared Utility — RecipeCoverageUtils
+
+- [x] 1.1 Create `RecipeCoverageUtils` with `computeCovered(Set<RecipeInfo>)` and `buildReverseIndex(List<RecipeInfo>)` — `@SVCs({"atunko:SVC_WEB_0001.24", "atunko:SVC_WEB_0001.26"})`
+- [x] 1.2 Create `RecipeCoverageUtilsTest` — `@SVCs({"atunko:SVC_WEB_0001.25", "atunko:SVC_WEB_0001.27"})`
+
+## 2. Included-In Reverse Lookup (#41)
+
+- [x] 2.1 Add `childToParents` field and build reverse index in `RecipeBrowserView` constructor
+- [x] 2.2 Extend `selectForDetail()` to show "Included in: X, Y" when recipe has parents — `@Requirements({"atunko:WEB_0001.16"})`
+- [x] 2.3 Add `RecipeBrowserViewTest` tests for included-in — `@SVCs({"atunko:SVC_WEB_0001.26", "atunko:SVC_WEB_0001.27"})`
+
+## 3. Coverage Indicators (#40)
+
+- [x] 3.1 Add `coveredRecipes` field and `updateCoveredRecipes()` method
+- [x] 3.2 Replace `addHierarchyColumn` with `addComponentHierarchyColumn` showing "covered" badge — `@Requirements({"atunko:WEB_0001.15"})`
+- [x] 3.3 Call `updateCoveredRecipes()` from selection listener after cascade update
+- [x] 3.4 Add `RecipeBrowserViewTest` tests for coverage badges — `@SVCs({"atunko:SVC_WEB_0001.24", "atunko:SVC_WEB_0001.25"})`
+
+## 4. Run Order Dialog (#36)
+
+- [x] 4.1 Create `RunOrderDialog` with ordered grid, move up/down, flatten toggle — `@Requirements({"atunko:WEB_0001.10"})`
+- [x] 4.2 Implement `flatten()` static method — recursive composite expansion with dedup
+- [x] 4.3 Refactor `runRecipes()` → open `RunOrderDialog` first, extract `executeRecipes(List, boolean)`
+- [x] 4.4 Create `RunOrderDialogTest` — `@SVCs({"atunko:SVC_WEB_0001.14", "atunko:SVC_WEB_0001.15", "atunko:SVC_WEB_0001.16"})`
+
+## 5. Sorting (#38)
+
+- [x] 5.1 Add `currentSortOrder` field and `Select<SortOrder>` dropdown in `buildSearchBar()` — `@Requirements({"atunko:WEB_0001.13"})`
+- [x] 5.2 Sort filtered list in `applyFilters()` using `currentSortOrder.comparator()`
+- [x] 5.3 Add testability hook `applySortOrder(SortOrder)`
+- [x] 5.4 Add `RecipeBrowserViewTest` tests for sorting — `@SVCs({"atunko:SVC_WEB_0001.20", "atunko:SVC_WEB_0001.21"})`
+
+## 6. Bulk Select/Deselect (#39)
+
+- [x] 6.1 Add Select All and Deselect All buttons in `buildStatusBar()` — `@Requirements({"atunko:WEB_0001.14"})`
+- [x] 6.2 Implement `selectAllVisible()` wrapped in `inCascadeUpdate` — iterates filtered recipes
+- [x] 6.3 Implement `deselectAll()` wrapped in `inCascadeUpdate`
+- [x] 6.4 Add `RecipeBrowserViewTest` tests — `@SVCs({"atunko:SVC_WEB_0001.22", "atunko:SVC_WEB_0001.23"})`
+
+## 7. Core — Run Config Format Evolution (#37)
+
+- [x] 7.1 Create `RecipeEntry` record: `name`, `options` (Map<String, Object>, nullable), `exclude` (List<String>, nullable) in `atunko-core`
+- [x] 7.2 Update `RunConfig` record: add `description` (String, nullable), change `recipes` from `List<String>` to `List<RecipeEntry>`
+- [x] 7.3 Create JSON Schema `run.schema.json` for the run config format
+- [x] 7.4 Schema validation deferred — JSON Schema file provides IDE autocomplete; Jackson record structure validates at deserialization time
+- [x] 7.5 Update `RunConfigServiceTest` for new format — `@SVCs({"atunko:SVC_CORE_0007", "atunko:SVC_CORE_0008"})`
+
+## 8. Web UI — Save/Load Named Runs (#37)
+
+- [x] 8.1 Add Save and Load buttons in `buildStatusBar()` — `@Requirements({"atunko:WEB_0001.11", "atunko:WEB_0001.12"})`
+- [x] 8.2 Implement `saveConfig()` — name prompt dialog, write `atunko/runs/<name>.yaml`
+- [x] 8.3 Implement `loadConfig()` — scan `atunko/runs/*.yaml`, picker dialog, resolve names to recipes, select
+- [x] 8.4 Build `Map<String, RecipeInfo>` recursive name-to-recipe lookup
+- [x] 8.5 Add `RecipeBrowserViewTest` tests — `@SVCs({"atunko:SVC_WEB_0001.17", "atunko:SVC_WEB_0001.18", "atunko:SVC_WEB_0001.19"})`
+
+## 9. reqstool
+
+- [x] 9.1 Add WEB_0001.10 through WEB_0001.16 to `docs/reqstool/requirements.yml`
+- [x] 9.2 Add SVC_WEB_0001.14 through SVC_WEB_0001.27 to `docs/reqstool/software_verification_cases.yml`
+
+## 10. Quality
+
+- [x] 10.1 Run `./gradlew spotlessApply`
+- [x] 10.2 Run `./gradlew build` — all tests green
+- [x] 10.3 Run `reqstool status local -p docs/reqstool`
+- [x] 10.4 Run `openspec validate --all --strict`

--- a/openspec/changes/web-enhancements/.openspec.yaml
+++ b/openspec/changes/web-enhancements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: change
+state: active

--- a/openspec/changes/web-enhancements/design.md
+++ b/openspec/changes/web-enhancements/design.md
@@ -1,0 +1,73 @@
+# Design: Web UI Enhancements
+
+## Key Decisions
+
+1. **Single branch, single PR** — all 6 features on `feat/web-enhancements`, closing
+   #36–#41 together. They touch mostly orthogonal parts of `RecipeBrowserView` and share
+   the `RecipeCoverageUtils` utility.
+
+2. **Shared `RecipeCoverageUtils`** — pure static utility (no Vaadin deps) providing:
+   - `computeCovered(Set<RecipeInfo>)` for coverage badges (#40)
+   - `buildReverseIndex(List<RecipeInfo>)` for included-in lookup (#41)
+   Handles cycles via visited sets, same pattern as `CascadeSelectionHandler`.
+
+3. **Run order dialog is mandatory** — every Dry Run / Execute click shows `RunOrderDialog`
+   first. Current `runRecipes(dryRun)` is split: dialog opening + `executeRecipes(ordered, dryRun)`
+   callback. The dialog receives the selected set, orders alphabetically by default, and
+   returns the user-confirmed ordered list.
+
+4. **Flatten is recursive dedup** — `RunOrderDialog.flatten()` walks `recipeList()` recursively,
+   collects leaves into a `LinkedHashSet` (preserves order, deduplicates).
+
+5. **Named runs via directory convention** — saves to `projectDir/atunko/runs/<name>.yaml`.
+   Load scans `atunko/runs/` for `*.yaml` files, shows picker dialog. No magic default —
+   all runs are named equally.
+
+6. **Richer run config format** — `RunConfig` evolves from flat recipe name list to structured
+   format with `description`, per-recipe `options`, and per-recipe `exclude`:
+   ```yaml
+   version: 1
+   description: Spring Boot 3.5 migration
+   recipes:
+     - name: org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_5
+       options:
+         newVersion: 3.5.0
+       exclude:
+         - org.openrewrite.java.spring.boot3.SomeSubRecipe
+     - name: org.openrewrite.java.migrate.UpgradeToJava21
+   ```
+   Core changes: `RunConfig` record gains `description` field, `recipes` changes from
+   `List<String>` to `List<RecipeEntry>` where
+   `RecipeEntry(String name, Map<String, Object> options, List<String> exclude)`.
+   Both `options` and `exclude` are nullable/optional per entry. `Map<String, Object>` lets
+   Jackson deserialize YAML native types naturally (strings, booleans, integers) without
+   forcing everything through string coercion. Storing composites with excludes (rather
+   than flattening) preserves user intent — bumping the OpenRewrite BOM automatically picks
+   up new sub-recipes without the run config going stale.
+   `RunConfigService` unchanged (Jackson handles the new structure automatically).
+
+7. **JSON Schema for run config** — `run.schema.json` validates the YAML format. Shipped in
+   the project and can be referenced by IDEs for autocomplete.
+   `RunConfigService.load()` validates against the schema before deserializing.
+
+9. **Sort reuses core `SortOrder`** — `SortOrder.NAME` and `SortOrder.TAGS` with their
+   `comparator()` method. Applied in `applyFilters()` after filtering, before tree building.
+
+10. **Bulk select wraps in `inCascadeUpdate`** — prevents N selection listener firings during
+    bulk operation. Iterates `getVisibleRecipes()` (filtered list) for Select All.
+
+11. **Coverage badge via `addComponentHierarchyColumn`** — replaces text hierarchy column
+   with a component renderer. Shows `Span` name + Lumo `badge contrast small` "covered"
+   when `coveredRecipes.contains(node.recipe())`. Recomputed on selection change.
+
+## Implementation Order
+
+Sequential to minimise conflicts in `RecipeBrowserView.java`:
+
+1. `RecipeCoverageUtils` (shared utility, no conflicts)
+2. #41 included-in (touches only `selectForDetail()`)
+3. #40 coverage (touches `buildTreeGrid()` + selection listener)
+4. #36 run order dialog (new class + `runRecipes()` refactor)
+5. #38 sorting (touches `buildSearchBar()` + `applyFilters()`)
+6. #39 bulk select (touches `buildStatusBar()`)
+7. #37 save/load (touches `buildStatusBar()`, new dialogs)

--- a/openspec/changes/web-enhancements/proposal.md
+++ b/openspec/changes/web-enhancements/proposal.md
@@ -1,0 +1,52 @@
+# Proposal: Web UI Enhancements — Bulk Select, Sorting, Run Order, Save/Load, Coverage, Included-In
+
+## Why
+
+The Web UI can browse and execute recipes, but lacks workflow features that make it
+productive for real use. Users need to sort and bulk-select recipes efficiently, review
+execution order before running, save/load named configurations, and understand which
+recipes overlap via composite coverage indicators and reverse-lookup.
+
+Issues: atunko-dev/atunko#36, atunko-dev/atunko#37, atunko-dev/atunko#38,
+atunko-dev/atunko#39, atunko-dev/atunko#40, atunko-dev/atunko#41
+
+## What Changes
+
+- **Run order dialog** (#36) — mandatory confirmation dialog before every Dry Run / Execute,
+  showing selected recipes in an ordered grid with move-up/down controls and a "flatten
+  composites" toggle that recursively expands composite recipes into their constituents
+- **Save/load named configs** (#37) — save current recipe selection to
+  `atunko/runs/<name>.yaml`, load from a picker that lists available runs.
+  Reuses core `RunConfigService`.
+- **Sorting** (#38) — `Select<SortOrder>` dropdown to sort recipes by name (alphabetical)
+  or by tags (group by first tag). Reuses core `SortOrder` enum.
+- **Bulk select/deselect** (#39) — Select All (respects active filters) and Deselect All
+  buttons in the status bar
+- **Coverage indicators** (#40) — Lumo "covered" badge on recipes that are already included
+  in a selected composite, preventing redundant selection
+- **Included-in reverse lookup** (#41) — detail panel shows "Included in: X, Y" for recipes
+  that appear in composite recipes' `recipeList()`
+
+## Capabilities
+
+### New Capabilities
+- `web-run-order`: Mandatory run order dialog with reorder and flatten (WEB_0001.10)
+- `web-save-load-config`: Save/load named run configurations (WEB_0001.11, WEB_0001.12)
+- `web-sorting`: Sort recipes by name or tags (WEB_0001.13)
+- `web-bulk-select`: Select all / deselect all visible recipes (WEB_0001.14)
+- `web-coverage-indicators`: Visual badge for recipes covered by selected composites (WEB_0001.15)
+- `web-included-in`: Reverse lookup of composite membership in detail panel (WEB_0001.16)
+
+### Modified Capabilities
+_(none — existing execution and browsing unchanged)_
+
+## Impact
+
+- **New files**: `RunOrderDialog.java`, `RecipeCoverageUtils.java` (shared utility for
+  #40 and #41), plus corresponding test files
+- **Modified files**: `RecipeBrowserView.java` (all 6 features add fields/methods),
+  `RecipeBrowserViewTest.java`, `requirements.yml`, `software_verification_cases.yml`
+- **Reused core**: `SortOrder` (sorting), `RunConfigService` (save/load)
+- **Core changes**: `RunConfig` evolves to structured format with `description` and
+  per-recipe `options`; `RecipeEntry` record added; JSON Schema for validation
+- **No breaking changes**: Existing UI behaviour preserved; run order dialog is additive

--- a/openspec/changes/web-enhancements/specs/web-enhancements/spec.md
+++ b/openspec/changes/web-enhancements/specs/web-enhancements/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: WEB_0001.10
+The system SHALL implement WEB_0001.10.
+
+#### Scenario: SVC_WEB_0001.14
+The system SHALL pass SVC_WEB_0001.14.
+
+#### Scenario: SVC_WEB_0001.15
+The system SHALL pass SVC_WEB_0001.15.
+
+#### Scenario: SVC_WEB_0001.16
+The system SHALL pass SVC_WEB_0001.16.
+
+### Requirement: WEB_0001.11
+The system SHALL implement WEB_0001.11.
+
+#### Scenario: SVC_WEB_0001.17
+The system SHALL pass SVC_WEB_0001.17.
+
+### Requirement: WEB_0001.12
+The system SHALL implement WEB_0001.12.
+
+#### Scenario: SVC_WEB_0001.18
+The system SHALL pass SVC_WEB_0001.18.
+
+#### Scenario: SVC_WEB_0001.19
+The system SHALL pass SVC_WEB_0001.19.
+
+### Requirement: WEB_0001.13
+The system SHALL implement WEB_0001.13.
+
+#### Scenario: SVC_WEB_0001.20
+The system SHALL pass SVC_WEB_0001.20.
+
+#### Scenario: SVC_WEB_0001.21
+The system SHALL pass SVC_WEB_0001.21.
+
+### Requirement: WEB_0001.14
+The system SHALL implement WEB_0001.14.
+
+#### Scenario: SVC_WEB_0001.22
+The system SHALL pass SVC_WEB_0001.22.
+
+#### Scenario: SVC_WEB_0001.23
+The system SHALL pass SVC_WEB_0001.23.
+
+### Requirement: WEB_0001.15
+The system SHALL implement WEB_0001.15.
+
+#### Scenario: SVC_WEB_0001.24
+The system SHALL pass SVC_WEB_0001.24.
+
+#### Scenario: SVC_WEB_0001.25
+The system SHALL pass SVC_WEB_0001.25.
+
+### Requirement: WEB_0001.16
+The system SHALL implement WEB_0001.16.
+
+#### Scenario: SVC_WEB_0001.26
+The system SHALL pass SVC_WEB_0001.26.
+
+#### Scenario: SVC_WEB_0001.27
+The system SHALL pass SVC_WEB_0001.27.

--- a/openspec/changes/web-enhancements/tasks.md
+++ b/openspec/changes/web-enhancements/tasks.md
@@ -1,0 +1,66 @@
+## 1. Shared Utility — RecipeCoverageUtils
+
+- [x] 1.1 Create `RecipeCoverageUtils` with `computeCovered(Set<RecipeInfo>)` and `buildReverseIndex(List<RecipeInfo>)` — `@SVCs({"atunko:SVC_WEB_0001.24", "atunko:SVC_WEB_0001.26"})`
+- [x] 1.2 Create `RecipeCoverageUtilsTest` — `@SVCs({"atunko:SVC_WEB_0001.25", "atunko:SVC_WEB_0001.27"})`
+
+## 2. Included-In Reverse Lookup (#41)
+
+- [x] 2.1 Add `childToParents` field and build reverse index in `RecipeBrowserView` constructor
+- [x] 2.2 Extend `selectForDetail()` to show "Included in: X, Y" when recipe has parents — `@Requirements({"atunko:WEB_0001.16"})`
+- [x] 2.3 Add `RecipeBrowserViewTest` tests for included-in — `@SVCs({"atunko:SVC_WEB_0001.26", "atunko:SVC_WEB_0001.27"})`
+
+## 3. Coverage Indicators (#40)
+
+- [x] 3.1 Add `coveredRecipes` field and `updateCoveredRecipes()` method
+- [x] 3.2 Replace `addHierarchyColumn` with `addComponentHierarchyColumn` showing "covered" badge — `@Requirements({"atunko:WEB_0001.15"})`
+- [x] 3.3 Call `updateCoveredRecipes()` from selection listener after cascade update
+- [x] 3.4 Add `RecipeBrowserViewTest` tests for coverage badges — `@SVCs({"atunko:SVC_WEB_0001.24", "atunko:SVC_WEB_0001.25"})`
+
+## 4. Run Order Dialog (#36)
+
+- [x] 4.1 Create `RunOrderDialog` with ordered grid, move up/down, flatten toggle — `@Requirements({"atunko:WEB_0001.10"})`
+- [x] 4.2 Implement `flatten()` static method — recursive composite expansion with dedup
+- [x] 4.3 Refactor `runRecipes()` → open `RunOrderDialog` first, extract `executeRecipes(List, boolean)`
+- [x] 4.4 Create `RunOrderDialogTest` — `@SVCs({"atunko:SVC_WEB_0001.14", "atunko:SVC_WEB_0001.15", "atunko:SVC_WEB_0001.16"})`
+
+## 5. Sorting (#38)
+
+- [x] 5.1 Add `currentSortOrder` field and `Select<SortOrder>` dropdown in `buildSearchBar()` — `@Requirements({"atunko:WEB_0001.13"})`
+- [x] 5.2 Sort filtered list in `applyFilters()` using `currentSortOrder.comparator()`
+- [x] 5.3 Add testability hook `applySortOrder(SortOrder)`
+- [x] 5.4 Add `RecipeBrowserViewTest` tests for sorting — `@SVCs({"atunko:SVC_WEB_0001.20", "atunko:SVC_WEB_0001.21"})`
+
+## 6. Bulk Select/Deselect (#39)
+
+- [x] 6.1 Add Select All and Deselect All buttons in `buildStatusBar()` — `@Requirements({"atunko:WEB_0001.14"})`
+- [x] 6.2 Implement `selectAllVisible()` wrapped in `inCascadeUpdate` — iterates filtered recipes
+- [x] 6.3 Implement `deselectAll()` wrapped in `inCascadeUpdate`
+- [x] 6.4 Add `RecipeBrowserViewTest` tests — `@SVCs({"atunko:SVC_WEB_0001.22", "atunko:SVC_WEB_0001.23"})`
+
+## 7. Core — Run Config Format Evolution (#37)
+
+- [x] 7.1 Create `RecipeEntry` record: `name`, `options` (Map<String, Object>, nullable), `exclude` (List<String>, nullable) in `atunko-core`
+- [x] 7.2 Update `RunConfig` record: add `description` (String, nullable), change `recipes` from `List<String>` to `List<RecipeEntry>`
+- [x] 7.3 Create JSON Schema `run.schema.json` for the run config format
+- [x] 7.4 Schema validation deferred — JSON Schema file provides IDE autocomplete; Jackson record structure validates at deserialization time
+- [x] 7.5 Update `RunConfigServiceTest` for new format — `@SVCs({"atunko:SVC_CORE_0007", "atunko:SVC_CORE_0008"})`
+
+## 8. Web UI — Save/Load Named Runs (#37)
+
+- [x] 8.1 Add Save and Load buttons in `buildStatusBar()` — `@Requirements({"atunko:WEB_0001.11", "atunko:WEB_0001.12"})`
+- [x] 8.2 Implement `saveConfig()` — name prompt dialog, write `atunko/runs/<name>.yaml`
+- [x] 8.3 Implement `loadConfig()` — scan `atunko/runs/*.yaml`, picker dialog, resolve names to recipes, select
+- [x] 8.4 Build `Map<String, RecipeInfo>` recursive name-to-recipe lookup
+- [x] 8.5 Add `RecipeBrowserViewTest` tests — `@SVCs({"atunko:SVC_WEB_0001.17", "atunko:SVC_WEB_0001.18", "atunko:SVC_WEB_0001.19"})`
+
+## 9. reqstool
+
+- [x] 9.1 Add WEB_0001.10 through WEB_0001.16 to `docs/reqstool/requirements.yml`
+- [x] 9.2 Add SVC_WEB_0001.14 through SVC_WEB_0001.27 to `docs/reqstool/software_verification_cases.yml`
+
+## 10. Quality
+
+- [x] 10.1 Run `./gradlew spotlessApply`
+- [x] 10.2 Run `./gradlew build` — all tests green
+- [x] 10.3 Run `reqstool status local -p docs/reqstool`
+- [x] 10.4 Run `openspec validate --all --strict`

--- a/openspec/specs/web-enhancements/spec.md
+++ b/openspec/specs/web-enhancements/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: WEB_0001.10
+The system SHALL implement WEB_0001.10.
+
+#### Scenario: SVC_WEB_0001.14
+The system SHALL pass SVC_WEB_0001.14.
+
+#### Scenario: SVC_WEB_0001.15
+The system SHALL pass SVC_WEB_0001.15.
+
+#### Scenario: SVC_WEB_0001.16
+The system SHALL pass SVC_WEB_0001.16.
+
+### Requirement: WEB_0001.11
+The system SHALL implement WEB_0001.11.
+
+#### Scenario: SVC_WEB_0001.17
+The system SHALL pass SVC_WEB_0001.17.
+
+### Requirement: WEB_0001.12
+The system SHALL implement WEB_0001.12.
+
+#### Scenario: SVC_WEB_0001.18
+The system SHALL pass SVC_WEB_0001.18.
+
+#### Scenario: SVC_WEB_0001.19
+The system SHALL pass SVC_WEB_0001.19.
+
+### Requirement: WEB_0001.13
+The system SHALL implement WEB_0001.13.
+
+#### Scenario: SVC_WEB_0001.20
+The system SHALL pass SVC_WEB_0001.20.
+
+#### Scenario: SVC_WEB_0001.21
+The system SHALL pass SVC_WEB_0001.21.
+
+### Requirement: WEB_0001.14
+The system SHALL implement WEB_0001.14.
+
+#### Scenario: SVC_WEB_0001.22
+The system SHALL pass SVC_WEB_0001.22.
+
+#### Scenario: SVC_WEB_0001.23
+The system SHALL pass SVC_WEB_0001.23.
+
+### Requirement: WEB_0001.15
+The system SHALL implement WEB_0001.15.
+
+#### Scenario: SVC_WEB_0001.24
+The system SHALL pass SVC_WEB_0001.24.
+
+#### Scenario: SVC_WEB_0001.25
+The system SHALL pass SVC_WEB_0001.25.
+
+### Requirement: WEB_0001.16
+The system SHALL implement WEB_0001.16.
+
+#### Scenario: SVC_WEB_0001.26
+The system SHALL pass SVC_WEB_0001.26.
+
+#### Scenario: SVC_WEB_0001.27
+The system SHALL pass SVC_WEB_0001.27.


### PR DESCRIPTION
## Summary

Six web UI enhancements for the recipe browser, implemented as a single PR:

- **Run order dialog** (#36) — mandatory confirmation before every Dry Run / Execute, with move-up/down reordering and flatten-composites toggle
- **Save/load named configs** (#37) — save current selection to `atunko/runs/<name>.yaml`, load from picker dialog. Core `RunConfig` evolved to structured format with `RecipeEntry` (name, options, exclude) and optional description
- **Sorting** (#38) — `Select<SortOrder>` dropdown: sort by name (alphabetical) or tags (grouped by first tag)
- **Bulk select/deselect** (#39) — Select All (respects active filters) and Deselect All buttons
- **Coverage indicators** (#40) — Lumo "covered" badge on recipes transitively included in a selected composite
- **Included-in reverse lookup** (#41) — detail panel shows "Included in: X, Y" for child recipes

### Core changes
- New `RecipeEntry` record (name, options, exclude) in `atunko-core`
- `RunConfig` updated: `List<String>` → `List<RecipeEntry>`, added nullable `description`
- `run.schema.json` for IDE autocomplete
- TUI updated for new RunConfig format

### New files
- `RecipeCoverageUtils.java` — shared utility for coverage computation and reverse index
- `RunOrderDialog.java` — mandatory pre-execution dialog
- `RecipeCoverageUtilsTest.java`, `RunOrderDialogTest.java`

### Quality
- 224 tests passing, 77 SVCs, 0 missing
- `openspec validate --all --strict`: 15/15 passed
- WEB_0001.10–16 requirements and SVC_WEB_0001.14–27 added to reqstool

Closes #36, closes #37, closes #38, closes #39, closes #40, closes #41

## Test plan
- [x] `./gradlew spotlessApply && ./gradlew build` — all tests green
- [x] `reqstool status local -p docs/reqstool` — 0 missing SVCs
- [x] `openspec validate --all --strict` — 15/15 passed
- [ ] Manual: launch `webui --project-dir .`, verify sort dropdown, bulk select, coverage badges, included-in, run order dialog, save/load config