### PR TITLE
feat(tui): add pilot-inspired keybinding enhancements

### DIFF
--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -122,6 +122,31 @@ public class TuiController {
             });
         }
 
+        public void selectAll() {
+            Set<String> visibleNames =
+                    displayRows().stream().map(r -> r.recipe().name()).collect(Collectors.toSet());
+            selectedRecipes.addAll(visibleNames);
+            if (cascade) {
+                recomputePartialState();
+            }
+        }
+
+        public void deselectAll() {
+            selectedRecipes.clear();
+            if (cascade) {
+                recomputePartialState();
+            }
+        }
+
+        public void expandAll(List<RecipeInfo> recipes) {
+            for (RecipeInfo r : recipes) {
+                if (r.isComposite()) {
+                    expandedRecipes.add(r.name());
+                    expandAll(r.recipeList());
+                }
+            }
+        }
+
         public void cycleSelection(boolean clearAllOnDeselect) {
             Set<String> visibleNames =
                     displayRows().stream().map(r -> r.recipe().name()).collect(Collectors.toSet());
@@ -489,6 +514,40 @@ public class TuiController {
         LOG.fine(() -> "Cycle selection: " + selectedRecipes.size() + " selected");
     }
 
+    @Requirements({"atunko:TUI_0001.5"})
+    public void selectAll() {
+        browserState.selectAll();
+    }
+
+    @Requirements({"atunko:TUI_0001.5"})
+    public void deselectAll() {
+        browserState.deselectAll();
+    }
+
+    public void expandAll() {
+        browserState.expandAll(recipes());
+    }
+
+    public void collapseAll() {
+        browserState.clearExpanded();
+    }
+
+    public void nextSearchMatch() {
+        int size = displayRows().size();
+        if (size == 0) {
+            return;
+        }
+        browserState.setHighlightedIndex((browserState.highlightedIndex() + 1) % size);
+    }
+
+    public void prevSearchMatch() {
+        int size = displayRows().size();
+        if (size == 0) {
+            return;
+        }
+        browserState.setHighlightedIndex((browserState.highlightedIndex() - 1 + size) % size);
+    }
+
     @Requirements({"atunko:TUI_0001.13"})
     public void collapseHighlighted() {
         browserState.collapseHighlighted();
@@ -671,6 +730,20 @@ public class TuiController {
     public void cycleRunSelection() {
         if (runState != null) {
             runState.cycleSelection(false);
+        }
+    }
+
+    @Requirements({"atunko:TUI_0001.14"})
+    public void selectAllRun() {
+        if (runState != null) {
+            runState.selectAll();
+        }
+    }
+
+    @Requirements({"atunko:TUI_0001.14"})
+    public void deselectAllRun() {
+        if (runState != null) {
+            runState.deselectAll();
         }
     }
 

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
@@ -83,11 +83,11 @@ public final class BrowserView {
 
     private static EventResult handleBrowseModeKey(
             TuiController controller, AtunkoTui app, dev.tamboui.tui.event.KeyEvent event) {
-        if (event.isDown()) {
+        if (event.isDown() || event.isChar('j')) {
             controller.moveDown();
             return EventResult.HANDLED;
         }
-        if (event.isUp()) {
+        if (event.isUp() || event.isChar('k')) {
             controller.moveUp();
             return EventResult.HANDLED;
         }
@@ -100,7 +100,19 @@ public final class BrowserView {
             return EventResult.HANDLED;
         }
         if (event.isChar('a')) {
-            controller.cycleSelection();
+            controller.selectAll();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('A')) {
+            controller.deselectAll();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('n') && !controller.searchQuery().isBlank()) {
+            controller.nextSearchMatch();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('N') && !controller.searchQuery().isBlank()) {
+            controller.prevSearchMatch();
             return EventResult.HANDLED;
         }
         if (event.isChar('r')) {
@@ -111,7 +123,7 @@ public final class BrowserView {
             controller.openTagBrowser();
             return EventResult.HANDLED;
         }
-        if (event.isRight() || event.isChar('e')) {
+        if (event.isRight() || event.isChar('e') || event.isChar('>')) {
             controller.highlightedDisplayRow().ifPresent(row -> {
                 if (row.recipe().isComposite()) {
                     controller.expandRecipe(row.recipe().name());
@@ -119,8 +131,16 @@ public final class BrowserView {
             });
             return EventResult.HANDLED;
         }
-        if (event.isLeft()) {
+        if (event.isLeft() || event.isChar('<')) {
             controller.collapseHighlighted();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('E')) {
+            controller.expandAll();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('W')) {
+            controller.collapseAll();
             return EventResult.HANDLED;
         }
         if (event.isQuit() || event.isChar('q')) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
@@ -92,11 +92,11 @@ public final class ConfirmRunView {
             return EventResult.HANDLED;
         }
         if (hasRecipes) {
-            if (event.isDown()) {
+            if (event.isDown() || event.isChar('j')) {
                 controller.moveRunHighlightDown();
                 return EventResult.HANDLED;
             }
-            if (event.isUp()) {
+            if (event.isUp() || event.isChar('k')) {
                 controller.moveRunHighlightUp();
                 return EventResult.HANDLED;
             }
@@ -113,14 +113,18 @@ public final class ConfirmRunView {
                 return EventResult.HANDLED;
             }
             if (event.isChar('a')) {
-                controller.cycleRunSelection();
+                controller.selectAllRun();
                 return EventResult.HANDLED;
             }
-            if (event.isRight() || event.isChar('e')) {
+            if (event.isChar('A')) {
+                controller.deselectAllRun();
+                return EventResult.HANDLED;
+            }
+            if (event.isRight() || event.isChar('e') || event.isChar('>')) {
                 controller.expandRunRecipe();
                 return EventResult.HANDLED;
             }
-            if (event.isLeft() || event.isChar('c')) {
+            if (event.isLeft() || event.isChar('c') || event.isChar('<')) {
                 controller.collapseRunRecipe();
                 return EventResult.HANDLED;
             }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
@@ -23,10 +23,17 @@ public final class HelpOverlay {
             new Section(
                     "Navigation",
                     List.of(
-                            new Entry("\u2191\u2193", "Move"),
-                            new Entry("\u2192", "Expand"),
-                            new Entry("\u2190", "Collapse"))),
-            new Section("Selection", List.of(new Entry("Space", "Toggle"), new Entry("a", "All/none"))),
+                            new Entry("\u2191\u2193/jk", "Move"),
+                            new Entry(">/\u2192", "Expand"),
+                            new Entry("</\u2190", "Collapse"),
+                            new Entry("E", "Expand all"),
+                            new Entry("W", "Collapse all"))),
+            new Section(
+                    "Selection",
+                    List.of(
+                            new Entry("Space", "Toggle"),
+                            new Entry("a", "Select all"),
+                            new Entry("A", "Deselect all"))),
             new Section(
                     "Actions",
                     List.of(
@@ -35,6 +42,7 @@ public final class HelpOverlay {
                             new Entry("t", "Tag browser"),
                             new Entry("s", "Sort order"),
                             new Entry("/", "Search"),
+                            new Entry("n/N", "Next/prev match"),
                             new Entry("Esc", "Clear all"),
                             new Entry("q", "Quit"))),
             new Section("Legend", List.of(new Entry("[x]", "Selected"), new Entry("[c]", "Covered by composite"))));
@@ -43,11 +51,16 @@ public final class HelpOverlay {
             new Section(
                     "Navigation",
                     List.of(
-                            new Entry("\u2191\u2193", "Move"),
+                            new Entry("\u2191\u2193/jk", "Move"),
                             new Entry("+/-", "Reorder"),
-                            new Entry("\u2192", "Expand"),
-                            new Entry("\u2190", "Collapse"))),
-            new Section("Selection", List.of(new Entry("Space", "Toggle"), new Entry("a", "All/none"))),
+                            new Entry(">/\u2192", "Expand"),
+                            new Entry("</\u2190", "Collapse"))),
+            new Section(
+                    "Selection",
+                    List.of(
+                            new Entry("Space", "Toggle"),
+                            new Entry("a", "Select all"),
+                            new Entry("A", "Deselect all"))),
             new Section(
                     "Actions",
                     List.of(

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
@@ -74,7 +74,7 @@ public final class TagBrowserView {
 
         String footer = tagSearchMode
                 ? " Type to filter | Enter:apply Esc:clear search"
-                : " \u2191\u2193:nav Space:sel Enter:apply /:search Esc:clear q:back";
+                : " \u2191\u2193/jk:nav Space:sel Enter:apply /:search Esc:clear q:back";
 
         return column(dock().top(header, Constraint.length(3))
                         .center(recipeList
@@ -109,11 +109,11 @@ public final class TagBrowserView {
             tagIndex = 0;
             return EventResult.HANDLED;
         }
-        if (event.isDown()) {
+        if (event.isDown() || event.isChar('j')) {
             tagIndex = Math.min(tagIndex + 1, Math.max(tags.size() - 1, 0));
             return EventResult.HANDLED;
         }
-        if (event.isUp()) {
+        if (event.isUp() || event.isChar('k')) {
             tagIndex = Math.max(tagIndex - 1, 0);
             return EventResult.HANDLED;
         }
@@ -126,11 +126,11 @@ public final class TagBrowserView {
 
     private static EventResult handleBrowseModeKey(
             TuiController controller, List<String> tags, dev.tamboui.tui.event.KeyEvent event) {
-        if (event.isDown()) {
+        if (event.isDown() || event.isChar('j')) {
             tagIndex = Math.min(tagIndex + 1, Math.max(tags.size() - 1, 0));
             return EventResult.HANDLED;
         }
-        if (event.isUp()) {
+        if (event.isUp() || event.isChar('k')) {
             tagIndex = Math.max(tagIndex - 1, 0);
             return EventResult.HANDLED;
         }


### PR DESCRIPTION
## Summary

Adopts keybinding conventions from [maveniverse/pilot](https://github.com/maveniverse/pilot), which uses the same TamboUI framework, to align atunko with established TUI idioms.

- **`j`/`k`** — vim-style navigation aliases for ↑/↓ in all list views (BrowserView, TagBrowserView, ConfirmRunView)
- **`n`/`N`** — jump to next/prev search match while browsing (only active when a search query is set)
- **`a` / `A`** — explicit select-all / deselect-all (replaces the cycle-toggle behaviour of `a`); mirrored in Run dialog
- **`E` / `W`** — expand all composites / collapse all in BrowserView (new `expandAll()` / `collapseAll()` in TuiController)
- **`<` / `>`** — expand/collapse aliases alongside existing arrow keys and `e`/`c` in BrowserView and ConfirmRunView
- **Help overlays + footer** updated to reflect all new keys

## Test plan

- [ ] `./gradlew build` passes (all tests green, Spotless + Checkstyle clean)
- [ ] `j`/`k` navigate in Browser, Tag Browser, and Run dialog
- [ ] `/` + query + `Enter`, then `n`/`N` cycles through filtered results
- [ ] `a` selects all; `A` deselects all (Browser and Run dialog)
- [ ] `E` expands all composites; `W` collapses them all
- [ ] `>` / `<` expand/collapse a single highlighted recipe
- [ ] `?` help overlay shows updated key descriptions in all three help contexts