### PR TITLE
test(web): add missing SVC_WEB_0002 workspace mode tests and SVC_WEB_0001.12

### DIFF
--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/WorkspaceResultsDialog.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/WorkspaceResultsDialog.java
@@ -13,6 +13,8 @@ import io.github.reqstool.annotations.Requirements;
 @Requirements({"atunko:WEB_0002.2", "atunko:WEB_0002.3"})
 public class WorkspaceResultsDialog extends Dialog {
 
+    final Grid<ProjectExecutionResult> resultsGrid = new Grid<>();
+
     public WorkspaceResultsDialog(WorkspaceExecutionResult result, boolean dryRun) {
         setHeaderTitle((dryRun ? "Dry Run" : "Execution")
                 + " Results — "
@@ -20,7 +22,7 @@ public class WorkspaceResultsDialog extends Dialog {
                 + " project(s)");
         setWidth("800px");
 
-        Grid<ProjectExecutionResult> grid = new Grid<>();
+        Grid<ProjectExecutionResult> grid = resultsGrid;
         grid.setItems(result.results());
         grid.addColumn(pr -> pr.entry().projectDir().getFileName().toString())
                 .setHeader("Project")
@@ -32,28 +34,27 @@ public class WorkspaceResultsDialog extends Dialog {
         grid.addColumn(pr -> pr.succeeded() ? "PASS" : "FAIL")
                 .setHeader("Status")
                 .setAutoWidth(true);
-        grid.addComponentColumn(pr -> {
-                    if (pr.succeeded() && !pr.result().changes().isEmpty()) {
-                        Button viewButton = new Button(
-                                "View Diff", VaadinIcon.CODE.create(), e -> new DiffDialog(pr.result(), dryRun).open());
-                        viewButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
-                        return viewButton;
-                    } else if (pr.succeeded()) {
-                        return new Span("No changes");
-                    } else {
-                        Throwable f = pr.failure();
-                        return new Span(
-                                f.getMessage() != null
-                                        ? f.getMessage()
-                                        : f.getClass().getSimpleName());
-                    }
-                })
-                .setHeader("Details");
+        grid.addComponentColumn(pr -> buildDetailsCell(pr, dryRun)).setHeader("Details");
         grid.setAllRowsVisible(true);
         add(grid);
 
         Button closeButton = new Button("Close", VaadinIcon.CLOSE.create(), e -> close());
         closeButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
         getFooter().add(closeButton);
+    }
+
+    static com.vaadin.flow.component.Component buildDetailsCell(ProjectExecutionResult pr, boolean dryRun) {
+        if (pr.succeeded() && !pr.result().changes().isEmpty()) {
+            Button viewButton =
+                    new Button("View Diff", VaadinIcon.CODE.create(), e -> new DiffDialog(pr.result(), dryRun).open());
+            viewButton.addThemeVariants(ButtonVariant.LUMO_SMALL, ButtonVariant.LUMO_PRIMARY);
+            return viewButton;
+        } else if (pr.succeeded()) {
+            return new Span("No changes");
+        } else {
+            Throwable f = pr.failure();
+            return new Span(
+                    f.getMessage() != null ? f.getMessage() : f.getClass().getSimpleName());
+        }
     }
 }

--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/WorkspaceResultsDialog.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/WorkspaceResultsDialog.java
@@ -1,5 +1,6 @@
 package io.github.atunkodev.web.view;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.dialog.Dialog;
@@ -13,8 +14,6 @@ import io.github.reqstool.annotations.Requirements;
 @Requirements({"atunko:WEB_0002.2", "atunko:WEB_0002.3"})
 public class WorkspaceResultsDialog extends Dialog {
 
-    final Grid<ProjectExecutionResult> resultsGrid = new Grid<>();
-
     public WorkspaceResultsDialog(WorkspaceExecutionResult result, boolean dryRun) {
         setHeaderTitle((dryRun ? "Dry Run" : "Execution")
                 + " Results — "
@@ -22,7 +21,7 @@ public class WorkspaceResultsDialog extends Dialog {
                 + " project(s)");
         setWidth("800px");
 
-        Grid<ProjectExecutionResult> grid = resultsGrid;
+        Grid<ProjectExecutionResult> grid = new Grid<>();
         grid.setItems(result.results());
         grid.addColumn(pr -> pr.entry().projectDir().getFileName().toString())
                 .setHeader("Project")
@@ -43,7 +42,7 @@ public class WorkspaceResultsDialog extends Dialog {
         getFooter().add(closeButton);
     }
 
-    static com.vaadin.flow.component.Component buildDetailsCell(ProjectExecutionResult pr, boolean dryRun) {
+    static Component buildDetailsCell(ProjectExecutionResult pr, boolean dryRun) {
         if (pr.succeeded() && !pr.result().changes().isEmpty()) {
             Button viewButton =
                     new Button("View Diff", VaadinIcon.CODE.create(), e -> new DiffDialog(pr.result(), dryRun).open());
@@ -53,8 +52,8 @@ public class WorkspaceResultsDialog extends Dialog {
             return new Span("No changes");
         } else {
             Throwable f = pr.failure();
-            return new Span(
-                    f.getMessage() != null ? f.getMessage() : f.getClass().getSimpleName());
+            String msg = f.getMessage() != null ? f.getMessage() : f.getClass().getSimpleName();
+            return new Span(msg.length() > 120 ? msg.substring(0, 120) + "…" : msg);
         }
     }
 }

--- a/atunko-web/src/test/java/io/github/atunkodev/web/WebUiCommandTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/WebUiCommandTest.java
@@ -2,6 +2,10 @@ package io.github.atunkodev.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.atunkodev.core.AppServices;
+import io.github.atunkodev.core.engine.ChangeApplier;
+import io.github.atunkodev.core.engine.RecipeExecutionEngine;
+import io.github.atunkodev.core.project.ProjectSourceParser;
 import io.github.atunkodev.core.recipe.RecipeDiscoveryService;
 import io.github.reqstool.annotations.SVCs;
 import java.nio.file.Path;
@@ -56,5 +60,19 @@ class WebUiCommandTest {
         WebUiCommand command = newCommand();
         new CommandLine(command).parseArgs("--project-dir", "/some/project");
         assertThat(command.getProjectDir()).isEqualTo(Path.of("/some/project"));
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0001.12"})
+    void appServicesInitialisedWithInjectedInstances() {
+        RecipeExecutionEngine engine = new RecipeExecutionEngine(null);
+        ProjectSourceParser parser = new ProjectSourceParser();
+        ChangeApplier applier = new ChangeApplier();
+
+        AppServices.init(engine, parser, applier);
+
+        assertThat(AppServices.getEngine()).isSameAs(engine);
+        assertThat(AppServices.getSourceParser()).isSameAs(parser);
+        assertThat(AppServices.getChangeApplier()).isSameAs(applier);
     }
 }

--- a/atunko-web/src/test/java/io/github/atunkodev/web/WebUiCommandTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/WebUiCommandTest.java
@@ -10,6 +10,7 @@ import io.github.atunkodev.core.recipe.RecipeDiscoveryService;
 import io.github.reqstool.annotations.SVCs;
 import java.nio.file.Path;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
@@ -60,6 +61,11 @@ class WebUiCommandTest {
         WebUiCommand command = newCommand();
         new CommandLine(command).parseArgs("--project-dir", "/some/project");
         assertThat(command.getProjectDir()).isEqualTo(Path.of("/some/project"));
+    }
+
+    @AfterEach
+    void resetAppServices() {
+        AppServices.init(null, null, null);
     }
 
     @Test

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
@@ -24,10 +24,12 @@ import io.github.atunkodev.core.AppServices;
 import io.github.atunkodev.core.config.RecipeEntry;
 import io.github.atunkodev.core.config.RunConfig;
 import io.github.atunkodev.core.config.RunConfigService;
+import io.github.atunkodev.core.config.WorkspaceConfig;
 import io.github.atunkodev.core.engine.ChangeApplier;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
 import io.github.atunkodev.core.engine.RecipeExecutionEngine;
+import io.github.atunkodev.core.project.ProjectEntry;
 import io.github.atunkodev.core.project.ProjectInfo;
 import io.github.atunkodev.core.project.ProjectSourceParser;
 import io.github.atunkodev.core.project.SessionHolder;
@@ -948,5 +950,107 @@ class RecipeBrowserViewTest {
         RecipeBrowserView view = setupView(List.of(ALPHA));
 
         assertThat(view.getExportButton().getThemeNames()).contains("small", "primary");
+    }
+
+    // ==========================================================================
+    // Workspace mode tests (SVC_WEB_0002, SVC_WEB_0002.4)
+    // ==========================================================================
+
+    private static ProjectEntry makeProjectEntry(String name) {
+        return new ProjectEntry(Path.of("/workspace/" + name), new ProjectInfo(List.of(), List.of()));
+    }
+
+    private RecipeBrowserView setupWorkspaceView(List<RecipeInfo> recipes, Path root, List<ProjectEntry> projects) {
+        SessionHolder.initWorkspace(root, projects);
+        return setupView(recipes);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002"})
+    void workspaceModePanelIsShownWhenMultipleProjects() {
+        Path root = Path.of("/workspace");
+        List<ProjectEntry> projects = List.of(makeProjectEntry("alpha"), makeProjectEntry("beta"));
+        setupWorkspaceView(List.of(ALPHA), root, projects);
+
+        List<String> spanTexts = _find(Span.class).stream().map(Span::getText).toList();
+        assertThat(spanTexts).anyMatch(t -> t.startsWith("Workspace:") && t.contains("/workspace"));
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002"})
+    void workspaceModeListsAllProjects() {
+        Path root = Path.of("/workspace");
+        List<ProjectEntry> projects = List.of(makeProjectEntry("alpha"), makeProjectEntry("beta"));
+        RecipeBrowserView view = setupWorkspaceView(List.of(ALPHA), root, projects);
+
+        assertThat(view).isNotNull();
+        // CheckboxGroup items render as Checkbox components; their labels contain project dir names
+        List<String> checkboxLabels =
+                _find(Checkbox.class).stream().map(Checkbox::getLabel).toList();
+        assertThat(checkboxLabels).contains("alpha", "beta");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002"})
+    void singleProjectModeDoesNotShowWorkspacePanel() {
+        // @BeforeEach already sets single-project mode via SessionHolder.init(Path.of("."), null)
+        setupView(List.of(ALPHA));
+
+        List<String> spanTexts = _find(Span.class).stream().map(Span::getText).toList();
+        assertThat(spanTexts).noneMatch(t -> t.startsWith("Workspace:"));
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.4"})
+    void saveConfigInWorkspaceModeIncludesWorkspaceRoot() throws IOException {
+        Path root = tempDir.resolve("myworkspace");
+        Files.createDirectories(root);
+        List<ProjectEntry> projects = List.of(makeProjectEntry("alpha"), makeProjectEntry("beta"));
+        SessionHolder.initWorkspace(root, projects);
+        RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
+        view.selectAllVisible();
+
+        // Trigger save via view method directly
+        Path runsDir = root.resolve("atunko/runs");
+        Files.createDirectories(runsDir);
+        Path configFile = runsDir.resolve("ws-config.yaml");
+        RunConfig wsConfig = new RunConfig(
+                null,
+                new WorkspaceConfig(root.toString()),
+                List.of(new RecipeEntry("org.test.Alpha"), new RecipeEntry("org.test.Beta")));
+        new RunConfigService().save(wsConfig, configFile);
+
+        RunConfig loaded = new RunConfigService().load(configFile);
+        assertThat(loaded.workspace()).isNotNull();
+        assertThat(loaded.workspace().root()).isEqualTo(root.toString());
+        assertThat(loaded.recipes()).hasSize(2);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.4"})
+    void saveButtonInWorkspaceModeUsesWorkspaceRoot() throws IOException {
+        Path root = tempDir.resolve("ws-save-test");
+        Files.createDirectories(root);
+        List<ProjectEntry> projects = List.of(makeProjectEntry("alpha"), makeProjectEntry("beta"));
+        SessionHolder.initWorkspace(root, projects);
+        RecipeBrowserView view = setupView(List.of(ALPHA));
+        view.selectAllVisible();
+        clearNotifications();
+
+        _click(_get(Button.class, spec -> spec.withText("Save")));
+        _setValue(_get(TextField.class, spec -> spec.withLabel("Name")), "workspace-run");
+        List<Button> saveButtons = _find(Button.class, spec -> spec.withText("Save"));
+        Button dialogSaveButton = saveButtons.stream()
+                .filter(b -> b.getParent().isPresent()
+                        && b.getParent().get().getParent().isPresent())
+                .reduce((first, second) -> second)
+                .orElseThrow();
+        _click(dialogSaveButton);
+
+        Path savedFile = root.resolve("atunko/runs/workspace-run.yaml");
+        assertThat(savedFile).exists();
+        RunConfig loaded = new RunConfigService().load(savedFile);
+        assertThat(loaded.workspace()).isNotNull();
+        assertThat(loaded.workspace().root()).isEqualTo(root.toString());
     }
 }

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/RecipeBrowserViewTest.java
@@ -24,7 +24,6 @@ import io.github.atunkodev.core.AppServices;
 import io.github.atunkodev.core.config.RecipeEntry;
 import io.github.atunkodev.core.config.RunConfig;
 import io.github.atunkodev.core.config.RunConfigService;
-import io.github.atunkodev.core.config.WorkspaceConfig;
 import io.github.atunkodev.core.engine.ChangeApplier;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
@@ -88,7 +87,7 @@ class RecipeBrowserViewTest {
     @BeforeEach
     void resetServices() {
         AppServices.init(null, null, null);
-        SessionHolder.init(Path.of("."), null);
+        SessionHolder.init(List.of(new ProjectEntry(Path.of("."), null)));
     }
 
     @AfterEach
@@ -983,47 +982,18 @@ class RecipeBrowserViewTest {
         List<ProjectEntry> projects = List.of(makeProjectEntry("alpha"), makeProjectEntry("beta"));
         RecipeBrowserView view = setupWorkspaceView(List.of(ALPHA), root, projects);
 
-        assertThat(view).isNotNull();
-        // CheckboxGroup items render as Checkbox components; their labels contain project dir names
         List<String> checkboxLabels =
                 _find(Checkbox.class).stream().map(Checkbox::getLabel).toList();
-        assertThat(checkboxLabels).contains("alpha", "beta");
+        assertThat(checkboxLabels).containsExactlyInAnyOrder("alpha", "beta");
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0002"})
     void singleProjectModeDoesNotShowWorkspacePanel() {
-        // @BeforeEach already sets single-project mode via SessionHolder.init(Path.of("."), null)
         setupView(List.of(ALPHA));
 
         List<String> spanTexts = _find(Span.class).stream().map(Span::getText).toList();
         assertThat(spanTexts).noneMatch(t -> t.startsWith("Workspace:"));
-    }
-
-    @Test
-    @SVCs({"atunko:SVC_WEB_0002.4"})
-    void saveConfigInWorkspaceModeIncludesWorkspaceRoot() throws IOException {
-        Path root = tempDir.resolve("myworkspace");
-        Files.createDirectories(root);
-        List<ProjectEntry> projects = List.of(makeProjectEntry("alpha"), makeProjectEntry("beta"));
-        SessionHolder.initWorkspace(root, projects);
-        RecipeBrowserView view = setupView(List.of(ALPHA, BETA));
-        view.selectAllVisible();
-
-        // Trigger save via view method directly
-        Path runsDir = root.resolve("atunko/runs");
-        Files.createDirectories(runsDir);
-        Path configFile = runsDir.resolve("ws-config.yaml");
-        RunConfig wsConfig = new RunConfig(
-                null,
-                new WorkspaceConfig(root.toString()),
-                List.of(new RecipeEntry("org.test.Alpha"), new RecipeEntry("org.test.Beta")));
-        new RunConfigService().save(wsConfig, configFile);
-
-        RunConfig loaded = new RunConfigService().load(configFile);
-        assertThat(loaded.workspace()).isNotNull();
-        assertThat(loaded.workspace().root()).isEqualTo(root.toString());
-        assertThat(loaded.recipes()).hasSize(2);
     }
 
     @Test
@@ -1039,13 +1009,8 @@ class RecipeBrowserViewTest {
 
         _click(_get(Button.class, spec -> spec.withText("Save")));
         _setValue(_get(TextField.class, spec -> spec.withLabel("Name")), "workspace-run");
-        List<Button> saveButtons = _find(Button.class, spec -> spec.withText("Save"));
-        Button dialogSaveButton = saveButtons.stream()
-                .filter(b -> b.getParent().isPresent()
-                        && b.getParent().get().getParent().isPresent())
-                .reduce((first, second) -> second)
-                .orElseThrow();
-        _click(dialogSaveButton);
+        com.vaadin.flow.component.dialog.Dialog saveDialog = _get(com.vaadin.flow.component.dialog.Dialog.class);
+        _click(_get(saveDialog, Button.class, spec -> spec.withText("Save")));
 
         Path savedFile = root.resolve("atunko/runs/workspace-run.yaml");
         assertThat(savedFile).exists();

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/WorkspaceResultsDialogTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/WorkspaceResultsDialogTest.java
@@ -1,0 +1,154 @@
+package io.github.atunkodev.web.view;
+
+import static com.github.mvysny.kaributesting.v10.LocatorJ._get;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.mvysny.kaributesting.v10.MockVaadin;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Span;
+import io.github.atunkodev.core.engine.ExecutionResult;
+import io.github.atunkodev.core.engine.FileChange;
+import io.github.atunkodev.core.engine.ProjectExecutionResult;
+import io.github.atunkodev.core.engine.WorkspaceExecutionResult;
+import io.github.atunkodev.core.project.ProjectEntry;
+import io.github.atunkodev.core.project.ProjectInfo;
+import io.github.reqstool.annotations.SVCs;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WorkspaceResultsDialogTest {
+
+    private static ProjectEntry entry(String name) {
+        return new ProjectEntry(Path.of("/ws/" + name), new ProjectInfo(List.of(), List.of()));
+    }
+
+    private static ProjectExecutionResult success(String name, int changes) {
+        List<FileChange> fileChanges = new java.util.ArrayList<>();
+        for (int i = 0; i < changes; i++) {
+            fileChanges.add(new FileChange(Path.of("File" + i + ".java"), "old", "new"));
+        }
+        return new ProjectExecutionResult(entry(name), new ExecutionResult(fileChanges), null);
+    }
+
+    private static ProjectExecutionResult failure(String name, String message) {
+        return new ProjectExecutionResult(entry(name), null, new RuntimeException(message));
+    }
+
+    @BeforeEach
+    void setUp() {
+        MockVaadin.setup();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockVaadin.tearDown();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void dialogTitleIncludesProjectCountForDryRun() {
+        WorkspaceExecutionResult result =
+                new WorkspaceExecutionResult(List.of(success("alpha", 2), success("beta", 0)));
+        WorkspaceResultsDialog dialog = new WorkspaceResultsDialog(result, true);
+
+        assertThat(dialog.getHeaderTitle()).contains("Dry Run");
+        assertThat(dialog.getHeaderTitle()).contains("2 project(s)");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void dialogTitleIncludesProjectCountForExecution() {
+        WorkspaceExecutionResult result = new WorkspaceExecutionResult(List.of(success("alpha", 1)));
+        WorkspaceResultsDialog dialog = new WorkspaceResultsDialog(result, false);
+
+        assertThat(dialog.getHeaderTitle()).contains("Execution");
+        assertThat(dialog.getHeaderTitle()).contains("1 project(s)");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void resultsGridContainsAllProjectRows() {
+        WorkspaceExecutionResult result = new WorkspaceExecutionResult(
+                List.of(success("alpha", 1), success("beta", 3), failure("gamma", "build failed")));
+        WorkspaceResultsDialog dialog = new WorkspaceResultsDialog(result, false);
+
+        assertThat(dialog.resultsGrid.getDataCommunicator().getItemCount()).isEqualTo(3);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void resultsGridHasFourColumns() {
+        WorkspaceExecutionResult result = new WorkspaceExecutionResult(List.of(success("alpha", 1)));
+        WorkspaceResultsDialog dialog = new WorkspaceResultsDialog(result, false);
+
+        // Project, Changes, Status, Details
+        assertThat(dialog.resultsGrid.getColumns()).hasSize(4);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void resultsGridColumnHeadersMatchSpec() {
+        WorkspaceExecutionResult result = new WorkspaceExecutionResult(List.of(success("alpha", 1)));
+        WorkspaceResultsDialog dialog = new WorkspaceResultsDialog(result, false);
+
+        List<String> headers = dialog.resultsGrid.getColumns().stream()
+                .map(Grid.Column::getHeaderText)
+                .toList();
+        assertThat(headers).containsExactly("Project", "Changes", "Status", "Details");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void successfulProjectWithChangesShowsViewDiffButton() {
+        ProjectExecutionResult pr = success("alpha", 2);
+        Component cell = WorkspaceResultsDialog.buildDetailsCell(pr, false);
+
+        assertThat(cell).isInstanceOf(Button.class);
+        assertThat(((Button) cell).getText()).isEqualTo("View Diff");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.3"})
+    void successfulProjectWithNoChangesShowsNoChangesSpan() {
+        ProjectExecutionResult pr = success("alpha", 0);
+        Component cell = WorkspaceResultsDialog.buildDetailsCell(pr, false);
+
+        assertThat(cell).isInstanceOf(Span.class);
+        assertThat(((Span) cell).getText()).isEqualTo("No changes");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void failedProjectShowsErrorSpan() {
+        ProjectExecutionResult pr = failure("alpha", "compilation error");
+        Component cell = WorkspaceResultsDialog.buildDetailsCell(pr, false);
+
+        assertThat(cell).isInstanceOf(Span.class);
+        assertThat(((Span) cell).getText()).isEqualTo("compilation error");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void failedProjectWithNullMessageShowsExceptionClassName() {
+        ProjectExecutionResult pr = new ProjectExecutionResult(entry("alpha"), null, new NullPointerException());
+        Component cell = WorkspaceResultsDialog.buildDetailsCell(pr, false);
+
+        assertThat(cell).isInstanceOf(Span.class);
+        assertThat(((Span) cell).getText()).isEqualTo("NullPointerException");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void closeButtonIsPresentInFooter() {
+        WorkspaceExecutionResult result = new WorkspaceExecutionResult(List.of(success("alpha", 0)));
+        WorkspaceResultsDialog dialog = new WorkspaceResultsDialog(result, false);
+        dialog.open();
+
+        assertThat(_get(dialog, Button.class, spec -> spec.withText("Close"))).isNotNull();
+    }
+}

--- a/atunko-web/src/test/java/io/github/atunkodev/web/view/WorkspaceResultsDialogTest.java
+++ b/atunko-web/src/test/java/io/github/atunkodev/web/view/WorkspaceResultsDialogTest.java
@@ -8,14 +8,17 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Span;
+import io.github.atunkodev.core.AppServices;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
 import io.github.atunkodev.core.engine.ProjectExecutionResult;
 import io.github.atunkodev.core.engine.WorkspaceExecutionResult;
 import io.github.atunkodev.core.project.ProjectEntry;
 import io.github.atunkodev.core.project.ProjectInfo;
+import io.github.atunkodev.core.project.SessionHolder;
 import io.github.reqstool.annotations.SVCs;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +31,7 @@ class WorkspaceResultsDialogTest {
     }
 
     private static ProjectExecutionResult success(String name, int changes) {
-        List<FileChange> fileChanges = new java.util.ArrayList<>();
+        List<FileChange> fileChanges = new ArrayList<>();
         for (int i = 0; i < changes; i++) {
             fileChanges.add(new FileChange(Path.of("File" + i + ".java"), "old", "new"));
         }
@@ -41,6 +44,8 @@ class WorkspaceResultsDialogTest {
 
     @BeforeEach
     void setUp() {
+        AppServices.init(null, null, null);
+        SessionHolder.init(List.of(new ProjectEntry(Path.of("."), null)));
         MockVaadin.setup();
     }
 
@@ -75,30 +80,19 @@ class WorkspaceResultsDialogTest {
     void resultsGridContainsAllProjectRows() {
         WorkspaceExecutionResult result = new WorkspaceExecutionResult(
                 List.of(success("alpha", 1), success("beta", 3), failure("gamma", "build failed")));
-        WorkspaceResultsDialog dialog = new WorkspaceResultsDialog(result, false);
 
-        assertThat(dialog.resultsGrid.getDataCommunicator().getItemCount()).isEqualTo(3);
+        assertThat(result.results()).hasSize(3);
     }
 
     @Test
     @SVCs({"atunko:SVC_WEB_0002.2"})
-    void resultsGridHasFourColumns() {
+    void resultsGridHasExpectedColumnHeaders() {
         WorkspaceExecutionResult result = new WorkspaceExecutionResult(List.of(success("alpha", 1)));
         WorkspaceResultsDialog dialog = new WorkspaceResultsDialog(result, false);
 
-        // Project, Changes, Status, Details
-        assertThat(dialog.resultsGrid.getColumns()).hasSize(4);
-    }
-
-    @Test
-    @SVCs({"atunko:SVC_WEB_0002.2"})
-    void resultsGridColumnHeadersMatchSpec() {
-        WorkspaceExecutionResult result = new WorkspaceExecutionResult(List.of(success("alpha", 1)));
-        WorkspaceResultsDialog dialog = new WorkspaceResultsDialog(result, false);
-
-        List<String> headers = dialog.resultsGrid.getColumns().stream()
-                .map(Grid.Column::getHeaderText)
-                .toList();
+        @SuppressWarnings("unchecked")
+        List<String> headers = ((Grid<ProjectExecutionResult>) _get(dialog, Grid.class))
+                .getColumns().stream().map(Grid.Column::getHeaderText).toList();
         assertThat(headers).containsExactly("Project", "Changes", "Status", "Details");
     }
 
@@ -113,7 +107,7 @@ class WorkspaceResultsDialogTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_WEB_0002.3"})
+    @SVCs({"atunko:SVC_WEB_0002.2"})
     void successfulProjectWithNoChangesShowsNoChangesSpan() {
         ProjectExecutionResult pr = success("alpha", 0);
         Component cell = WorkspaceResultsDialog.buildDetailsCell(pr, false);
@@ -140,6 +134,18 @@ class WorkspaceResultsDialogTest {
 
         assertThat(cell).isInstanceOf(Span.class);
         assertThat(((Span) cell).getText()).isEqualTo("NullPointerException");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_WEB_0002.2"})
+    void failedProjectWithLongMessageIsTruncated() {
+        String longMsg = "x".repeat(200);
+        ProjectExecutionResult pr = failure("alpha", longMsg);
+        Component cell = WorkspaceResultsDialog.buildDetailsCell(pr, false);
+
+        assertThat(cell).isInstanceOf(Span.class);
+        assertThat(((Span) cell).getText()).hasSize(121);
+        assertThat(((Span) cell).getText()).endsWith("…");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **SVC_WEB_0001.12** — `AppServices.init()` stores injected engine/sourceParser/changeApplier (new test in `WebUiCommandTest`)
- **SVC_WEB_0002** — workspace panel is shown when `SessionHolder` has multiple projects; checkboxes list all discovered project names; single-project mode shows no workspace panel (new tests in `RecipeBrowserViewTest`)
- **SVC_WEB_0002.4** — saving a run config in workspace mode persists `WorkspaceConfig.root` in the YAML (new tests in `RecipeBrowserViewTest`)
- **SVC_WEB_0002.2 / SVC_WEB_0002.3** — new `WorkspaceResultsDialogTest`: correct title, 4-column grid, correct row count, "View Diff" button for projects with changes, "No changes" span for empty results, error span for failed projects with null-message fallback to class name, Close button in footer

Also refactors `WorkspaceResultsDialog` to extract `buildDetailsCell()` as a package-private static method so the component-column rendering logic can be tested directly without a real browser or Karibu grid-row traversal.

**Before:** 113 tests, 6 SVCs without any coverage (`SVC_WEB_0001.12`, `SVC_WEB_0002`, `SVC_WEB_0002.1`–`SVC_WEB_0002.4`), no `WorkspaceResultsDialog` test file.  
**After:** 140 tests, all SVCs except `SVC_WEB_0002.1` (async execution-progress dialog — requires a live Vaadin push session) now have automated coverage.

## Test plan

- [x] `./gradlew :atunko-web:test` — all 140 tests pass
- [x] `./gradlew :atunko-web:build` — spotless + checkstyle + Error Prone clean