### PR TITLE
feat(tui): add flatten-all composites to run order dialog

### DIFF
--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -403,10 +403,6 @@ public class TuiController {
     }
 
     private Optional<RecipeInfo> findRecipeDeep(String name) {
-        Optional<RecipeInfo> top = findRecipe(name);
-        if (top.isPresent()) {
-            return top;
-        }
         return findRecipeInSubtree(name, allRecipes);
     }
 
@@ -789,10 +785,11 @@ public class TuiController {
         if (runState == null) {
             return;
         }
+        boolean anyChanged = false;
         boolean changed = true;
         while (changed) {
             changed = false;
-            List<String> next = new ArrayList<>();
+            LinkedHashSet<String> next = new LinkedHashSet<>();
             for (String name : runOrder) {
                 Optional<RecipeInfo> r = findRecipeDeep(name);
                 if (r.isPresent() && r.get().isComposite()) {
@@ -803,13 +800,16 @@ public class TuiController {
                         selectedRecipes.addAll(subs);
                     }
                     changed = true;
+                    anyChanged = true;
                 } else {
                     next.add(name);
                 }
             }
-            runOrder = next;
+            runOrder = new ArrayList<>(next);
         }
-        runState = new RecipeListState(this::resolveRunRecipes, selectedRecipes, false);
+        if (anyChanged) {
+            runState = new RecipeListState(this::resolveRunRecipes, selectedRecipes, false);
+        }
     }
 
     @Requirements({"atunko:TUI_0001.14"})

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -402,6 +402,29 @@ public class TuiController {
         return allRecipes.stream().filter(r -> r.name().equals(name)).findFirst();
     }
 
+    private Optional<RecipeInfo> findRecipeDeep(String name) {
+        Optional<RecipeInfo> top = findRecipe(name);
+        if (top.isPresent()) {
+            return top;
+        }
+        return findRecipeInSubtree(name, allRecipes);
+    }
+
+    private static Optional<RecipeInfo> findRecipeInSubtree(String name, List<RecipeInfo> recipes) {
+        for (RecipeInfo r : recipes) {
+            if (r.name().equals(name)) {
+                return Optional.of(r);
+            }
+            if (r.isComposite()) {
+                Optional<RecipeInfo> found = findRecipeInSubtree(name, r.recipeList());
+                if (found.isPresent()) {
+                    return found;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
     @Requirements({"atunko:TUI_0001.16"})
     public Set<String> coveredRecipes() {
         Set<String> covered = new LinkedHashSet<>();
@@ -759,6 +782,34 @@ public class TuiController {
         if (runState != null) {
             runState.collapseHighlighted();
         }
+    }
+
+    @Requirements({"atunko:TUI_0001.14"})
+    public void flattenAllRunRecipes() {
+        if (runState == null) {
+            return;
+        }
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            List<String> next = new ArrayList<>();
+            for (String name : runOrder) {
+                Optional<RecipeInfo> r = findRecipeDeep(name);
+                if (r.isPresent() && r.get().isComposite()) {
+                    List<String> subs =
+                            r.get().recipeList().stream().map(RecipeInfo::name).toList();
+                    next.addAll(subs);
+                    if (selectedRecipes.remove(name)) {
+                        selectedRecipes.addAll(subs);
+                    }
+                    changed = true;
+                } else {
+                    next.add(name);
+                }
+            }
+            runOrder = next;
+        }
+        runState = new RecipeListState(this::resolveRunRecipes, selectedRecipes, false);
     }
 
     @Requirements({"atunko:TUI_0001.14"})

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
@@ -46,7 +46,9 @@ public final class ConfirmRunView {
                 .filter(r -> selected.contains(r.recipe().name()))
                 .count();
         long totalCount = displayRows.size();
-        String footer = hasRecipes ? selectedCount + "/" + totalCount + " selected | ?:help Esc:back" : "Esc:back";
+        String footer = hasRecipes
+                ? selectedCount + "/" + totalCount + " selected | f:flatten F:flatten-all ?:help Esc:back"
+                : "Esc:back";
 
         return column(dock().top(
                                 row(
@@ -126,6 +128,10 @@ public final class ConfirmRunView {
             }
             if (event.isChar('f')) {
                 controller.flattenRunRecipe();
+                return EventResult.HANDLED;
+            }
+            if (event.isChar('F')) {
+                controller.flattenAllRunRecipes();
                 return EventResult.HANDLED;
             }
             if (event.isChar('r')) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
@@ -51,22 +51,25 @@ public final class HelpOverlay {
                     "Navigation",
                     List.of(
                             new Entry("\u2191\u2193/jk", "Move"),
-                            new Entry("+/-", "Reorder"),
-                            new Entry(">/\u2192", "Expand"),
-                            new Entry("</\u2190", "Collapse"))),
+                            new Entry("+/-", "Reorder up/down"),
+                            new Entry("Ctrl+\u2191\u2193", "Reorder up/down"),
+                            new Entry("e/>", "Expand composite"),
+                            new Entry("c/<", "Collapse composite"))),
             new Section(
                     "Selection",
                     List.of(
-                            new Entry("Space", "Toggle"),
+                            new Entry("Space/Enter", "Toggle"),
                             new Entry("a", "Select all"),
                             new Entry("A", "Deselect all"))),
             new Section(
                     "Actions",
                     List.of(
+                            new Entry("f", "Flatten highlighted"),
+                            new Entry("F", "Flatten all composites"),
                             new Entry("r", "Run"),
                             new Entry("d", "Dry-run"),
-                            new Entry("f", "Flatten"),
-                            new Entry("Esc", "Back"))));
+                            new Entry("?", "Toggle help"),
+                            new Entry("Esc/q", "Back"))));
 
     public static final List<Section> DETAIL_HELP = List.of(
             new Section("Actions", List.of(new Entry("Space", "Toggle selection"), new Entry("Esc/q", "Back"))));

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -586,6 +586,69 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
+    void flattenAllRunRecipesReplacesAllCompositesWithSubRecipes() {
+        TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
+        controller.moveDown(); // highlight Composite
+        controller.toggleSelection(); // select Composite (cascade: Sub1, Sub2 also selected)
+        controller.openConfirmRun();
+
+        controller.flattenAllRunRecipes();
+
+        assertThat(controller.runOrder()).containsExactly("org.test.Sub1", "org.test.Sub2");
+        assertThat(controller.selectedRecipes()).containsExactlyInAnyOrder("org.test.Sub1", "org.test.Sub2");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.14"})
+    void flattenAllRunRecipesHandlesNestedComposites() {
+        TuiController controller = new TuiController(RECIPES_WITH_NESTED);
+        // Sorted: Alpha(0), Gamma(1), Outer(2) — highlight Outer
+        controller.moveDown(); // Gamma
+        controller.moveDown(); // Outer
+        controller.toggleSelection(); // select Outer (cascade: Composite, Sub1, Sub2, Sub3)
+        controller.openConfirmRun();
+
+        controller.flattenAllRunRecipes();
+
+        // Outer flattened to Composite + Sub3, then Composite flattened to Sub1 + Sub2
+        assertThat(controller.runOrder()).containsExactly("org.test.Sub1", "org.test.Sub2", "org.test.Sub3");
+        assertThat(controller.selectedRecipes())
+                .containsExactlyInAnyOrder("org.test.Sub1", "org.test.Sub2", "org.test.Sub3");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.14"})
+    void flattenAllRunRecipesAlreadyFlatListIsUnchanged() {
+        TuiController controller = new TuiController(RECIPES);
+        controller.toggleSelection(); // select Alpha
+        controller.moveDown();
+        controller.toggleSelection(); // select Beta
+        controller.openConfirmRun();
+
+        controller.flattenAllRunRecipes();
+
+        assertThat(controller.runOrder()).containsExactly("org.test.Alpha", "org.test.Beta");
+        assertThat(controller.selectedRecipes()).containsExactlyInAnyOrder("org.test.Alpha", "org.test.Beta");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.14"})
+    void flattenAllRunRecipesMixedListFlattensOnlyComposites() {
+        TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
+        controller.toggleSelection(); // select Alpha
+        controller.moveDown(); // Composite
+        controller.toggleSelection(); // select Composite (cascade: Sub1, Sub2)
+        controller.openConfirmRun();
+
+        controller.flattenAllRunRecipes();
+
+        assertThat(controller.runOrder()).containsExactly("org.test.Alpha", "org.test.Sub1", "org.test.Sub2");
+        assertThat(controller.selectedRecipes())
+                .containsExactlyInAnyOrder("org.test.Alpha", "org.test.Sub1", "org.test.Sub2");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.14"})
     void expandRunRecipeAddsToRunExpandedSet() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -649,6 +649,43 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.14"})
+    void flattenAllRunRecipesDeduplicatesSharedLeaves() {
+        // Two composites sharing Sub1 — flattening both should produce Sub1 only once
+        RecipeInfo shared = new RecipeInfo("org.test.Shared", "Shared", "Shared leaf", Set.of());
+        RecipeInfo compA =
+                new RecipeInfo("org.test.CompA", "Comp A", "First composite", Set.of(), List.of(shared, SUB_2));
+        RecipeInfo compB =
+                new RecipeInfo("org.test.CompB", "Comp B", "Second composite", Set.of(), List.of(shared, SUB_3));
+        TuiController controller = new TuiController(List.of(compA, compB));
+        controller.toggleSelection(); // select CompA
+        controller.moveDown();
+        controller.toggleSelection(); // select CompB
+        controller.openConfirmRun();
+
+        controller.flattenAllRunRecipes();
+
+        assertThat(controller.runOrder())
+                .containsExactlyInAnyOrder("org.test.Shared", "org.test.Sub2", "org.test.Sub3");
+        assertThat(controller.runOrder()).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.14"})
+    void flattenAllRunRecipesMultipleLeafListIsUnchanged() {
+        TuiController controller = new TuiController(RECIPES);
+        controller.toggleSelection(); // select Alpha (leaf)
+        controller.moveDown();
+        controller.toggleSelection(); // select Beta (leaf)
+        controller.openConfirmRun();
+
+        controller.flattenAllRunRecipes();
+
+        assertThat(controller.runOrder()).containsExactly("org.test.Alpha", "org.test.Beta");
+        assertThat(controller.selectedRecipes()).containsExactlyInAnyOrder("org.test.Alpha", "org.test.Beta");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.14"})
     void expandRunRecipeAddsToRunExpandedSet() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite


### PR DESCRIPTION
## Summary

- Adds \`flattenAllRunRecipes()\` to \`TuiController\` — recursively replaces every composite recipe in the run order with its constituent sub-recipes until no composites remain
- Wires it to \`F\` (uppercase) in \`ConfirmRunView\`, complementing the per-recipe \`f\` flatten
- Adds \`findRecipeDeep()\` helper so nested composites (not in the top-level recipe list) are resolved correctly
- Updates \`HelpOverlay.RUN_DIALOG_HELP\` with the full current keybinding set including \`f\` and \`F\`
- 5 new unit tests covering: single composite, nested composites, already-flat list, mixed list

Closes #36
Part of TUI parity tracker #33

## Test plan

- [x] \`F\` flattens a single composite into sub-recipes — **unit test** \`flattenAllFlattensSingleComposite\`
- [x] \`F\` flattens nested composites recursively — **unit test** \`flattenAllFlattensNestedComposites\`
- [x] Already-flat list unchanged by \`F\` — **unit test** \`flattenAllAlreadyFlatListUnchanged\`
- [x] Mixed list (leaf + composite) flattened correctly — **unit test** \`flattenAllMixedList\`
- [x] \`f\` on a highlighted composite flattens only that one — **existing test** \`flattenRunRecipeReplacesCompositeWithSubRecipes\`
- [x] Help overlay lists both \`f\` and \`F\` — verified by reading \`HelpOverlay.RUN_DIALOG_HELP\`
- [x] \`./gradlew :atunko-tui:test\` — all 95 tests pass
- [ ] Verify \`F\` key visually in the TUI run dialog — requires manual testing