### PR TITLE
feat(tui): add save/load run configuration

### DIFF
--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
@@ -10,6 +10,7 @@ import io.github.atunkodev.tui.view.BrowserView;
 import io.github.atunkodev.tui.view.ConfirmRunView;
 import io.github.atunkodev.tui.view.DetailView;
 import io.github.atunkodev.tui.view.ExecutionResultsView;
+import io.github.atunkodev.tui.view.LoadConfigView;
 import io.github.atunkodev.tui.view.TagBrowserView;
 import io.github.reqstool.annotations.Requirements;
 import java.io.IOException;
@@ -47,6 +48,7 @@ public class AtunkoTui extends ToolkitApp {
             case TAG_BROWSER -> TagBrowserView.render(controller);
             case EXECUTION_RESULTS -> ExecutionResultsView.render(controller);
             case CONFIRM_RUN -> ConfirmRunView.render(controller);
+            case LOAD_CONFIG -> LoadConfigView.render(controller);
         };
     }
 

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/Screen.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/Screen.java
@@ -5,5 +5,6 @@ public enum Screen {
     DETAIL,
     TAG_BROWSER,
     CONFIRM_RUN,
-    EXECUTION_RESULTS
+    EXECUTION_RESULTS,
+    LOAD_CONFIG
 }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -14,6 +14,7 @@ import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.core.recipe.SortOrder;
 import io.github.reqstool.annotations.Requirements;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -919,12 +920,13 @@ public class TuiController {
         browserState.resetHighlight();
     }
 
+    @Requirements({"atunko:TUI_0001.10"})
     public List<Path> listRunConfigs() {
         Path dir = projectDir.resolve("atunko/runs");
-        if (!java.nio.file.Files.isDirectory(dir)) {
+        if (!Files.isDirectory(dir)) {
             return List.of();
         }
-        try (var stream = java.nio.file.Files.list(dir)) {
+        try (var stream = Files.list(dir)) {
             return stream.filter(p -> p.toString().endsWith(".yml")).sorted().toList();
         } catch (IOException e) {
             return List.of();
@@ -998,7 +1000,7 @@ public class TuiController {
             return;
         }
         Path dir = projectDir.resolve("atunko/runs");
-        java.nio.file.Files.createDirectories(dir);
+        Files.createDirectories(dir);
         saveRunConfig(dir.resolve(saveConfigName + ".yml"));
         exitSaveConfigMode();
     }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -912,6 +912,97 @@ public class TuiController {
         runConfigService.save(config, file);
     }
 
+    @Requirements({"atunko:TUI_0001.10"})
+    public void loadRunConfig(RunConfig config) {
+        selectedRecipes.clear();
+        config.recipes().stream().map(RecipeEntry::name).forEach(selectedRecipes::add);
+        browserState.resetHighlight();
+    }
+
+    public List<Path> listRunConfigs() {
+        Path dir = projectDir.resolve("atunko/runs");
+        if (!java.nio.file.Files.isDirectory(dir)) {
+            return List.of();
+        }
+        try (var stream = java.nio.file.Files.list(dir)) {
+            return stream.filter(p -> p.toString().endsWith(".yml")).sorted().toList();
+        } catch (IOException e) {
+            return List.of();
+        }
+    }
+
+    private int loadConfigHighlightIndex = 0;
+    private List<Path> configFiles = List.of();
+
+    public void openLoadConfig() {
+        configFiles = listRunConfigs();
+        loadConfigHighlightIndex = 0;
+        currentScreen = Screen.LOAD_CONFIG;
+    }
+
+    public List<Path> configFiles() {
+        return configFiles;
+    }
+
+    public int loadConfigHighlightIndex() {
+        return loadConfigHighlightIndex;
+    }
+
+    public void moveLoadConfigDown() {
+        if (!configFiles.isEmpty()) {
+            loadConfigHighlightIndex = Math.min(loadConfigHighlightIndex + 1, configFiles.size() - 1);
+        }
+    }
+
+    public void moveLoadConfigUp() {
+        loadConfigHighlightIndex = Math.max(0, loadConfigHighlightIndex - 1);
+    }
+
+    public void confirmLoadConfig() throws IOException {
+        if (configFiles.isEmpty()) {
+            return;
+        }
+        RunConfig config = runConfigService.load(configFiles.get(loadConfigHighlightIndex));
+        loadRunConfig(config);
+        currentScreen = Screen.BROWSER;
+    }
+
+    private boolean saveConfigMode = false;
+    private String saveConfigName = "";
+
+    public boolean isSaveConfigMode() {
+        return saveConfigMode;
+    }
+
+    public String saveConfigName() {
+        return saveConfigName;
+    }
+
+    public void enterSaveConfigMode() {
+        saveConfigMode = true;
+        saveConfigName = "";
+    }
+
+    public void exitSaveConfigMode() {
+        saveConfigMode = false;
+        saveConfigName = "";
+    }
+
+    public void setSaveConfigName(String name) {
+        saveConfigName = name;
+    }
+
+    public void confirmSaveConfig() throws IOException {
+        if (saveConfigName.isBlank()) {
+            exitSaveConfigMode();
+            return;
+        }
+        Path dir = projectDir.resolve("atunko/runs");
+        java.nio.file.Files.createDirectories(dir);
+        saveRunConfig(dir.resolve(saveConfigName + ".yml"));
+        exitSaveConfigMode();
+    }
+
     private List<RecipeInfo> filterRecipes() {
         var stream = allRecipes.stream();
         if (!selectedTags.isEmpty()) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
@@ -20,10 +20,12 @@ import io.github.atunkodev.tui.TuiController;
 import io.github.atunkodev.tui.TuiController.DisplayRow;
 import io.github.reqstool.annotations.Requirements;
 import java.util.List;
+import java.util.logging.Logger;
 
 @Requirements({"atunko:TUI_0001.1", "atunko:TUI_0001.2", "atunko:TUI_0001.13"})
 public final class BrowserView {
 
+    private static final Logger LOG = Logger.getLogger(BrowserView.class.getName());
     private static final TextInputState SEARCH_STATE = new TextInputState();
     private static final TextInputState SAVE_NAME_STATE = new TextInputState();
 
@@ -75,8 +77,6 @@ public final class BrowserView {
         }
         return handleBrowseModeKey(controller, app, event);
     }
-
-    private static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(BrowserView.class.getName());
 
     private static EventResult handleSaveConfigModeKey(TuiController controller, dev.tamboui.tui.event.KeyEvent event) {
         if (event.isConfirm()) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
@@ -25,6 +25,7 @@ import java.util.List;
 public final class BrowserView {
 
     private static final TextInputState SEARCH_STATE = new TextInputState();
+    private static final TextInputState SAVE_NAME_STATE = new TextInputState();
 
     private BrowserView() {}
 
@@ -40,9 +41,19 @@ public final class BrowserView {
                     .constraint(Constraint.fill());
         }
 
+        Element bottomBar = controller.isSaveConfigMode()
+                ? row(
+                        text(" Save config: ").addClass("detail-label"),
+                        textInput(SAVE_NAME_STATE)
+                                .placeholder("config-name")
+                                .rounded()
+                                .constraint(Constraint.fill()),
+                        text("  Enter:save  Esc:cancel "))
+                : renderStatusBar(controller, displayRows);
+
         return column(dock().top(renderHeader(controller), Constraint.length(3))
                         .center(centerContent)
-                        .bottom(renderStatusBar(controller, displayRows), Constraint.length(1))
+                        .bottom(bottomBar, Constraint.length(1))
                         .constraint(Constraint.fill()))
                 .id("browser")
                 .addClass("app")
@@ -56,10 +67,35 @@ public final class BrowserView {
             controller.toggleHelp();
             return EventResult.HANDLED;
         }
+        if (controller.isSaveConfigMode()) {
+            return handleSaveConfigModeKey(controller, event);
+        }
         if (controller.isSearchMode()) {
             return handleSearchModeKey(controller, event);
         }
         return handleBrowseModeKey(controller, app, event);
+    }
+
+    private static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(BrowserView.class.getName());
+
+    private static EventResult handleSaveConfigModeKey(TuiController controller, dev.tamboui.tui.event.KeyEvent event) {
+        if (event.isConfirm()) {
+            try {
+                controller.confirmSaveConfig();
+            } catch (java.io.IOException e) {
+                LOG.log(java.util.logging.Level.WARNING, "Failed to save run config", e);
+            }
+            return EventResult.HANDLED;
+        }
+        if (event.code() == dev.tamboui.tui.event.KeyCode.ESCAPE) {
+            controller.exitSaveConfigMode();
+            return EventResult.HANDLED;
+        }
+        if (handleTextInputKey(SAVE_NAME_STATE, event)) {
+            controller.setSaveConfigName(SAVE_NAME_STATE.text());
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
     }
 
     private static EventResult handleSearchModeKey(TuiController controller, dev.tamboui.tui.event.KeyEvent event) {
@@ -162,6 +198,15 @@ public final class BrowserView {
         }
         if (event.isChar('?')) {
             controller.toggleHelp();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('S')) {
+            SAVE_NAME_STATE.clear();
+            controller.enterSaveConfigMode();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('L')) {
+            controller.openLoadConfig();
             return EventResult.HANDLED;
         }
         return EventResult.UNHANDLED;

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/HelpOverlay.java
@@ -40,6 +40,8 @@ public final class HelpOverlay {
                             new Entry("r", "Run dialog"),
                             new Entry("t", "Tag browser"),
                             new Entry("s", "Sort order"),
+                            new Entry("S", "Save run config"),
+                            new Entry("L", "Load run config"),
                             new Entry("/", "Search"),
                             new Entry("n/N", "Next/prev match"),
                             new Entry("Esc", "Clear all"),

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
@@ -51,7 +51,7 @@ public final class LoadConfigView {
 
         Element statusBar = text(" j/k:navigate  Enter:load  Esc/q:back").addClass("status-bar");
 
-        return column(dock().top(header, Constraint.length(3))
+        return column(dock().top(header, Constraint.length(1))
                         .center(centerContent)
                         .bottom(statusBar, Constraint.length(1))
                         .constraint(Constraint.fill()))

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
@@ -1,0 +1,86 @@
+package io.github.atunkodev.tui.view;
+
+import static dev.tamboui.toolkit.Toolkit.column;
+import static dev.tamboui.toolkit.Toolkit.dock;
+import static dev.tamboui.toolkit.Toolkit.row;
+import static dev.tamboui.toolkit.Toolkit.spacer;
+import static dev.tamboui.toolkit.Toolkit.text;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.event.EventResult;
+import io.github.atunkodev.tui.TuiController;
+import io.github.reqstool.annotations.Requirements;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Requirements({"atunko:TUI_0001.10"})
+public final class LoadConfigView {
+
+    private static final Logger LOG = Logger.getLogger(LoadConfigView.class.getName());
+
+    private LoadConfigView() {}
+
+    public static Element render(TuiController controller) {
+        List<Path> configFiles = controller.configFiles();
+        int highlightIndex = controller.loadConfigHighlightIndex();
+
+        Element centerContent;
+        if (configFiles.isEmpty()) {
+            centerContent = column(
+                    text(""),
+                    text(" No saved configurations found.").addClass("unselected"),
+                    text(" Save one first with S in the browser.").addClass("unselected"));
+        } else {
+            var listColumn = column();
+            for (int i = 0; i < configFiles.size(); i++) {
+                String filename = configFiles.get(i).getFileName().toString();
+                if (i == highlightIndex) {
+                    listColumn.add(text(" > " + filename).addClass("highlighted"));
+                } else {
+                    listColumn.add(text("   " + filename));
+                }
+            }
+            centerContent = listColumn;
+        }
+
+        String countText = configFiles.isEmpty() ? "" : configFiles.size() + " configs found";
+        Element header = row(text(" Load Config ").addClass("screen-title"), spacer(), text(countText));
+
+        Element statusBar = text(" j/k:navigate  Enter:load  Esc/q:back").addClass("status-bar");
+
+        return column(dock().top(header, Constraint.length(3))
+                        .center(centerContent)
+                        .bottom(statusBar, Constraint.length(1))
+                        .constraint(Constraint.fill()))
+                .id("load-config")
+                .focusable()
+                .onKeyEvent(event -> handleKeyEvent(controller, event));
+    }
+
+    private static EventResult handleKeyEvent(TuiController controller, dev.tamboui.tui.event.KeyEvent event) {
+        if (event.isDown() || event.isChar('j')) {
+            controller.moveLoadConfigDown();
+            return EventResult.HANDLED;
+        }
+        if (event.isUp() || event.isChar('k')) {
+            controller.moveLoadConfigUp();
+            return EventResult.HANDLED;
+        }
+        if (event.isConfirm()) {
+            try {
+                controller.confirmLoadConfig();
+            } catch (java.io.IOException e) {
+                LOG.log(Level.WARNING, "Failed to load run config", e);
+            }
+            return EventResult.HANDLED;
+        }
+        if (event.code() == dev.tamboui.tui.event.KeyCode.ESCAPE || event.isChar('q')) {
+            controller.goBack();
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
+    }
+}

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -370,6 +370,187 @@ class TuiControllerTest {
                 .containsExactlyInAnyOrder("org.test.Alpha", "org.test.Beta");
     }
 
+    // --- Load Run Configuration ---
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void loadRunConfigRestoresRecipeSelection(@TempDir Path tempDir) throws Exception {
+        RunConfigService service = new RunConfigService();
+        TuiController controller = new TuiController(RECIPES, service);
+        controller.toggleSelection(); // select Alpha
+        controller.moveDown();
+        controller.toggleSelection(); // select Beta
+        Path configFile = tempDir.resolve("myconfig.yml");
+        controller.saveRunConfig(configFile);
+        controller.deselectAll();
+
+        RunConfig loaded = service.load(configFile);
+        controller.loadRunConfig(loaded);
+
+        assertThat(controller.selectedRecipes()).containsExactlyInAnyOrder("org.test.Alpha", "org.test.Beta");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void loadRunConfigReplacesExistingSelection(@TempDir Path tempDir) throws Exception {
+        RunConfigService service = new RunConfigService();
+        TuiController controller = new TuiController(RECIPES, service);
+        controller.toggleSelection(); // select Alpha (cursor at 0)
+        Path configFile = tempDir.resolve("alpha.yml");
+        controller.saveRunConfig(configFile);
+        // Switch to a different selection before loading
+        controller.deselectAll();
+        controller.moveDown();
+        controller.moveDown();
+        controller.toggleSelection(); // select Gamma
+        assertThat(controller.selectedRecipes()).containsExactly("org.test.Gamma");
+
+        RunConfig loaded = service.load(configFile);
+        controller.loadRunConfig(loaded);
+
+        assertThat(controller.selectedRecipes()).containsExactly("org.test.Alpha");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void listRunConfigsReturnsEmptyWhenDirectoryAbsent(@TempDir Path tempDir) {
+        TuiController controller = new TuiController(RECIPES, new RunConfigService(), null, null, null, tempDir);
+
+        List<Path> configs = controller.listRunConfigs();
+
+        assertThat(configs).isEmpty();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void listRunConfigsReturnsYmlFiles(@TempDir Path tempDir) throws Exception {
+        RunConfigService service = new RunConfigService();
+        TuiController controller = new TuiController(RECIPES, service, null, null, null, tempDir);
+        controller.toggleSelection();
+        java.nio.file.Files.createDirectories(tempDir.resolve("atunko/runs"));
+        controller.saveRunConfig(tempDir.resolve("atunko/runs/first.yml"));
+        controller.saveRunConfig(tempDir.resolve("atunko/runs/second.yml"));
+
+        List<Path> configs = controller.listRunConfigs();
+
+        assertThat(configs).hasSize(2);
+        assertThat(configs).allMatch(p -> p.toString().endsWith(".yml"));
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void confirmSaveConfigWritesFileUnderProjectDir(@TempDir Path tempDir) throws Exception {
+        RunConfigService service = new RunConfigService();
+        TuiController controller = new TuiController(RECIPES, service, null, null, null, tempDir);
+        controller.toggleSelection(); // select Alpha
+        controller.enterSaveConfigMode();
+        controller.setSaveConfigName("my-run");
+
+        controller.confirmSaveConfig();
+
+        Path expected = tempDir.resolve("atunko/runs/my-run.yml");
+        assertThat(expected).exists();
+        RunConfig loaded = service.load(expected);
+        assertThat(loaded.recipes()).hasSize(1);
+        assertThat(loaded.recipes().get(0).name()).isEqualTo("org.test.Alpha");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void confirmSaveConfigWithBlankNameExitsWithoutSaving(@TempDir Path tempDir) throws Exception {
+        TuiController controller = new TuiController(RECIPES, new RunConfigService(), null, null, null, tempDir);
+        controller.toggleSelection();
+        controller.enterSaveConfigMode();
+        controller.setSaveConfigName("   ");
+
+        controller.confirmSaveConfig();
+
+        assertThat(controller.isSaveConfigMode()).isFalse();
+        assertThat(tempDir.resolve("atunko/runs")).doesNotExist();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void enterSaveConfigModeSetsModeFlag() {
+        TuiController controller = new TuiController(RECIPES);
+
+        controller.enterSaveConfigMode();
+
+        assertThat(controller.isSaveConfigMode()).isTrue();
+        assertThat(controller.saveConfigName()).isEmpty();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void exitSaveConfigModeClearsFlag() {
+        TuiController controller = new TuiController(RECIPES);
+        controller.enterSaveConfigMode();
+        controller.setSaveConfigName("draft");
+
+        controller.exitSaveConfigMode();
+
+        assertThat(controller.isSaveConfigMode()).isFalse();
+        assertThat(controller.saveConfigName()).isEmpty();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void openLoadConfigSetsScreenAndPopulatesFileList(@TempDir Path tempDir) throws Exception {
+        RunConfigService service = new RunConfigService();
+        TuiController controller = new TuiController(RECIPES, service, null, null, null, tempDir);
+        controller.toggleSelection();
+        java.nio.file.Files.createDirectories(tempDir.resolve("atunko/runs"));
+        controller.saveRunConfig(tempDir.resolve("atunko/runs/saved.yml"));
+
+        controller.openLoadConfig();
+
+        assertThat(controller.currentScreen()).isEqualTo(Screen.LOAD_CONFIG);
+        assertThat(controller.configFiles()).hasSize(1);
+        assertThat(controller.loadConfigHighlightIndex()).isZero();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void confirmLoadConfigLoadsFileAndReturnsToBrowser(@TempDir Path tempDir) throws Exception {
+        RunConfigService service = new RunConfigService();
+        TuiController controller = new TuiController(RECIPES, service, null, null, null, tempDir);
+        controller.moveDown();
+        controller.toggleSelection(); // select Beta
+        java.nio.file.Files.createDirectories(tempDir.resolve("atunko/runs"));
+        controller.saveRunConfig(tempDir.resolve("atunko/runs/beta.yml"));
+        controller.deselectAll();
+
+        controller.openLoadConfig();
+        controller.confirmLoadConfig();
+
+        assertThat(controller.currentScreen()).isEqualTo(Screen.BROWSER);
+        assertThat(controller.selectedRecipes()).containsExactly("org.test.Beta");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.10"})
+    void moveLoadConfigDownAndUpNavigatesList(@TempDir Path tempDir) throws Exception {
+        RunConfigService service = new RunConfigService();
+        TuiController controller = new TuiController(RECIPES, service, null, null, null, tempDir);
+        controller.toggleSelection();
+        java.nio.file.Files.createDirectories(tempDir.resolve("atunko/runs"));
+        controller.saveRunConfig(tempDir.resolve("atunko/runs/aaa.yml"));
+        controller.saveRunConfig(tempDir.resolve("atunko/runs/bbb.yml"));
+        controller.openLoadConfig();
+
+        controller.moveLoadConfigDown();
+        assertThat(controller.loadConfigHighlightIndex()).isEqualTo(1);
+
+        controller.moveLoadConfigDown(); // clamp at 1
+        assertThat(controller.loadConfigHighlightIndex()).isEqualTo(1);
+
+        controller.moveLoadConfigUp();
+        assertThat(controller.loadConfigHighlightIndex()).isZero();
+
+        controller.moveLoadConfigUp(); // clamp at 0
+        assertThat(controller.loadConfigHighlightIndex()).isZero();
+    }
+
     // --- Cycle Selection ---
 
     @Test


### PR DESCRIPTION
## Summary

- Press \`S\` in the browser to enter save-config mode: type a name and press \`Enter\` to write the current recipe selection to \`atunko/runs/<name>.yml\`
- Press \`L\` to open \`LoadConfigView\` — a navigable list of saved \`.yml\` configs; press \`Enter\` to load one back into the browser selection
- Adds \`Screen.LOAD_CONFIG\`, \`LoadConfigView\`, and save/load prompt state in \`TuiController\`
- \`BrowserView\` bottom bar switches to an inline text prompt while in save-config mode
- Help overlay updated with \`S\` and \`L\` entries

Closes #37
Part of TUI parity tracker #33

## Test plan

- [x] \`confirmSaveConfig()\` writes \`atunko/runs/<name>.yml\` — **unit test** \`confirmSaveConfigWritesFileUnderProjectDir\`
- [x] Blank name exits save mode without creating any file — **unit test** \`confirmSaveConfigWithBlankNameExitsWithoutSaving\`
- [x] \`enterSaveConfigMode\` sets flag; \`exitSaveConfigMode\` clears it — **unit tests**
- [x] \`L\` opens \`LOAD_CONFIG\` screen and populates file list — **unit test** \`openLoadConfigSetsScreenAndPopulatesFileList\`
- [x] \`confirmLoadConfig\` loads file and returns to \`BROWSER\` — **unit test** \`confirmLoadConfigLoadsFileAndReturnsToBrowser\`
- [x] Load replaces current selection entirely — **unit test** \`loadRunConfigReplacesExistingSelection\`
- [x] \`listRunConfigs\` returns empty when directory absent — **unit test** \`listRunConfigsReturnsEmptyWhenDirectoryAbsent\`
- [x] \`listRunConfigs\` returns \`.yml\` files — **unit test** \`listRunConfigsReturnsYmlFiles\`
- [x] Navigation \`j\`/\`k\` and clamping in load-config list — **unit test** \`moveLoadConfigDownAndUpNavigatesList\`
- [x] \`S\`/\`L\` appear in help overlay — verified by reading \`HelpOverlay.BROWSER_HELP\`
- [ ] Verify save prompt renders in status bar and loads interactively — requires manual TUI testing