### PR TITLE
chore(deps): upgrade TamboUI 0.2.0-SNAPSHOT → 0.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,6 @@ allprojects {
                 includeGroup 'org.gradle'
             }
         }
-        maven {
-            url = 'https://central.sonatype.com/repository/maven-snapshots/'
-            mavenContent { snapshotsOnly() }
-        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 openrewrite-bom = "3.25.0"
 picocli = "4.7.7"
 gradle-tooling-api = "9.3.1"
-tamboui = "0.2.0-SNAPSHOT"
+tamboui = "0.3.0"
 reqstool-annotations = "1.0.0"
 junit = "5.11.4"
 assertj = "3.27.3"


### PR DESCRIPTION
## Summary

- Bumps `tamboui` from `0.2.0-SNAPSHOT` to `0.3.0` in `gradle/libs.versions.toml`
- Removes the Sonatype snapshot repository from `build.gradle` — `0.3.0` is published to Maven Central
- No source changes required: 0.3.0 is a drop-in upgrade with no breaking API changes

## What's new in 0.3.0

- **List scrolling bug fix** — directly improves `ExecutionResultsView`, `LoadConfigView`, and `TagBrowserView`
- Markdown viewer with streaming support
- Improved Unicode/emoji and bracketed paste handling
- Multiple render threads support

## Merge order

Merge this PR **before** #55, #56, and #57 so those branches pick up the stable release when they rebase.

## Test plan

- [x] `./gradlew build` passes — all 54 tasks, all tests green
- [x] Snapshot repository removed from `build.gradle`