### PR TITLE
feat(tui): render recipe descriptions as markdown in detail view

### DIFF
--- a/atunko-tui/build.gradle
+++ b/atunko-tui/build.gradle
@@ -15,4 +15,5 @@ dependencies {
     implementation libs.tamboui.css
     implementation libs.tamboui.picocli
     implementation libs.tamboui.jline3.backend
+    implementation libs.tamboui.toolkit.markdown
 }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
@@ -33,10 +33,7 @@ public final class DetailView {
     // parents:   blank(1) + "Included in:"(1)
     // +1 buffer so a wrapping name/tag line doesn't push the description off-screen
     static int metadataLineCount(RecipeInfo recipe, int parentCount) {
-        return 4
-                + (recipe.isComposite() ? 2 + recipe.recipeList().size() : 0)
-                + (parentCount > 0 ? 2 : 0)
-                + 1;
+        return 4 + (recipe.isComposite() ? 2 + recipe.recipeList().size() : 0) + (parentCount > 0 ? 2 : 0) + 1;
     }
 
     private static Element renderRecipeDetail(TuiController controller, RecipeInfo recipe) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
@@ -6,6 +6,7 @@ import static dev.tamboui.toolkit.Toolkit.panel;
 import static dev.tamboui.toolkit.Toolkit.row;
 import static dev.tamboui.toolkit.Toolkit.spacer;
 import static dev.tamboui.toolkit.Toolkit.text;
+import static dev.tamboui.toolkit.markdown.MarkdownElement.markdown;
 
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
@@ -33,25 +34,23 @@ public final class DetailView {
                 ? text("Selected ").addClass("selected")
                 : text("Not selected ").addClass("unselected");
 
-        var detailContent = column(
+        var metadataContent = column(
                 row(text("Name: ").addClass("detail-label"), text(recipe.name())),
                 row(
                         text("Display Name: ").addClass("detail-label"),
                         text(RecipeListRenderer.cleanDisplayName(recipe.displayName()))),
                 text(""),
-                text("Description:").addClass("detail-label"),
-                text(recipe.description() != null ? recipe.description() : "(none)"),
-                text(""),
-                text("Tags:").addClass("detail-label"),
-                text(recipe.tags().isEmpty() ? "(none)" : String.join(", ", recipe.tags()))
-                        .addClass("detail-value"));
+                row(
+                        text("Tags: ").addClass("detail-label"),
+                        text(recipe.tags().isEmpty() ? "(none)" : String.join(", ", recipe.tags()))
+                                .addClass("detail-value")));
 
         if (recipe.isComposite()) {
-            detailContent.add(text(""));
-            detailContent.add(text("Recipe List:").addClass("detail-label"));
+            metadataContent.add(text(""));
+            metadataContent.add(text("Recipe List:").addClass("detail-label"));
             int index = 1;
             for (RecipeInfo sub : recipe.recipeList()) {
-                detailContent.add(row(
+                metadataContent.add(row(
                         text("  " + index + ". ").addClass("included-in"),
                         text(RecipeListRenderer.cleanDisplayName(sub.displayName()))
                                 .addClass("detail-value")));
@@ -61,17 +60,27 @@ public final class DetailView {
 
         List<String> parents = controller.includedIn(recipe.name());
         if (!parents.isEmpty()) {
-            detailContent.add(text(""));
-            detailContent.add(row(
+            metadataContent.add(text(""));
+            metadataContent.add(row(
                     text("Included in: ").addClass("detail-label", "included-in"),
                     text(String.join(", ", parents)).addClass("included-in")));
         }
+
+        int metadataLines =
+                4 + (recipe.isComposite() ? 2 + recipe.recipeList().size() : 0) + (!parents.isEmpty() ? 2 : 0);
+
+        String description = recipe.description() != null ? recipe.description() : "*(no description)*";
 
         Element centerContent;
         if (controller.isShowHelp()) {
             centerContent = row(spacer(), HelpOverlay.render(HelpOverlay.DETAIL_HELP), spacer());
         } else {
-            centerContent = panel("Recipe Detail", detailContent).addClass("panel");
+            centerContent = panel(
+                            "Detail",
+                            dock().top(metadataContent, Constraint.length(metadataLines))
+                                    .center(markdown(description))
+                                    .constraint(Constraint.fill()))
+                    .addClass("panel");
         }
 
         return column(dock().top(

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
@@ -28,6 +28,17 @@ public final class DetailView {
                 .orElse(text("No recipe selected"));
     }
 
+    // Name(1) + DisplayName(1) + blank(1) + Tags(1) = 4 base rows
+    // composite: blank(1) + "Recipe List:"(1) + N sub-recipes
+    // parents:   blank(1) + "Included in:"(1)
+    // +1 buffer so a wrapping name/tag line doesn't push the description off-screen
+    static int metadataLineCount(RecipeInfo recipe, int parentCount) {
+        return 4
+                + (recipe.isComposite() ? 2 + recipe.recipeList().size() : 0)
+                + (parentCount > 0 ? 2 : 0)
+                + 1;
+    }
+
     private static Element renderRecipeDetail(TuiController controller, RecipeInfo recipe) {
         boolean selected = controller.selectedRecipes().contains(recipe.name());
         var selectionLabel = selected
@@ -66,9 +77,6 @@ public final class DetailView {
                     text(String.join(", ", parents)).addClass("included-in")));
         }
 
-        int metadataLines =
-                4 + (recipe.isComposite() ? 2 + recipe.recipeList().size() : 0) + (!parents.isEmpty() ? 2 : 0);
-
         String description = recipe.description() != null ? recipe.description() : "*(no description)*";
 
         Element centerContent;
@@ -76,8 +84,8 @@ public final class DetailView {
             centerContent = row(spacer(), HelpOverlay.render(HelpOverlay.DETAIL_HELP), spacer());
         } else {
             centerContent = panel(
-                            "Detail",
-                            dock().top(metadataContent, Constraint.length(metadataLines))
+                            "Recipe Detail",
+                            dock().top(metadataContent, Constraint.length(metadataLineCount(recipe, parents.size())))
                                     .center(markdown(description))
                                     .constraint(Constraint.fill()))
                     .addClass("panel");

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/view/DetailViewTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/view/DetailViewTest.java
@@ -13,12 +13,9 @@ class DetailViewTest {
 
     private static final RecipeInfo LEAF =
             new RecipeInfo("org.test.Leaf", "Leaf Recipe", "A leaf recipe", Set.of("java"));
-    private static final RecipeInfo SUB_1 =
-            new RecipeInfo("org.test.Sub1", "Sub 1", "First sub", Set.of());
-    private static final RecipeInfo SUB_2 =
-            new RecipeInfo("org.test.Sub2", "Sub 2", "Second sub", Set.of());
-    private static final RecipeInfo SUB_3 =
-            new RecipeInfo("org.test.Sub3", "Sub 3", "Third sub", Set.of());
+    private static final RecipeInfo SUB_1 = new RecipeInfo("org.test.Sub1", "Sub 1", "First sub", Set.of());
+    private static final RecipeInfo SUB_2 = new RecipeInfo("org.test.Sub2", "Sub 2", "Second sub", Set.of());
+    private static final RecipeInfo SUB_3 = new RecipeInfo("org.test.Sub3", "Sub 3", "Third sub", Set.of());
     private static final RecipeInfo COMPOSITE = new RecipeInfo(
             "org.test.Composite", "Composite Recipe", "A composite", Set.of(), List.of(SUB_1, SUB_2, SUB_3));
 

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/view/DetailViewTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/view/DetailViewTest.java
@@ -1,0 +1,63 @@
+package io.github.atunkodev.tui.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.reqstool.annotations.SVCs;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+@SVCs({"atunko:SVC_TUI_0001.4"})
+class DetailViewTest {
+
+    private static final RecipeInfo LEAF =
+            new RecipeInfo("org.test.Leaf", "Leaf Recipe", "A leaf recipe", Set.of("java"));
+    private static final RecipeInfo SUB_1 =
+            new RecipeInfo("org.test.Sub1", "Sub 1", "First sub", Set.of());
+    private static final RecipeInfo SUB_2 =
+            new RecipeInfo("org.test.Sub2", "Sub 2", "Second sub", Set.of());
+    private static final RecipeInfo SUB_3 =
+            new RecipeInfo("org.test.Sub3", "Sub 3", "Third sub", Set.of());
+    private static final RecipeInfo COMPOSITE = new RecipeInfo(
+            "org.test.Composite", "Composite Recipe", "A composite", Set.of(), List.of(SUB_1, SUB_2, SUB_3));
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.4"})
+    void metadataLineCountLeafNoParents() {
+        // 4 base + 1 buffer = 5
+        assertThat(DetailView.metadataLineCount(LEAF, 0)).isEqualTo(5);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.4"})
+    void metadataLineCountLeafWithParents() {
+        // 4 base + 2 (blank + included-in row) + 1 buffer = 7
+        assertThat(DetailView.metadataLineCount(LEAF, 2)).isEqualTo(7);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.4"})
+    void metadataLineCountCompositeNoParents() {
+        // 4 base + 2 (blank + "Recipe List:" label) + 3 sub-recipes + 1 buffer = 10
+        assertThat(DetailView.metadataLineCount(COMPOSITE, 0)).isEqualTo(10);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.4"})
+    void metadataLineCountCompositeWithParents() {
+        // 4 base + 2 + 3 subs + 2 (blank + included-in) + 1 buffer = 12
+        assertThat(DetailView.metadataLineCount(COMPOSITE, 1)).isEqualTo(12);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.4"})
+    void metadataLineCountBufferIsAlwaysPresent() {
+        int withoutParents = DetailView.metadataLineCount(LEAF, 0);
+        int withParents = DetailView.metadataLineCount(LEAF, 1);
+
+        // buffer means result is always > the raw row count
+        assertThat(withoutParents).isGreaterThan(4);
+        assertThat(withParents).isGreaterThan(6);
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ tamboui-toolkit = { module = "dev.tamboui:tamboui-toolkit" }
 tamboui-css = { module = "dev.tamboui:tamboui-css" }
 tamboui-picocli = { module = "dev.tamboui:tamboui-picocli" }
 tamboui-jline3-backend = { module = "dev.tamboui:tamboui-jline3-backend" }
+tamboui-toolkit-markdown = { module = "dev.tamboui:tamboui-toolkit-markdown" }
 
 # reqstool
 reqstool-annotations = { module = "io.github.reqstool:reqstool-java-annotations", version.ref = "reqstool-annotations" }


### PR DESCRIPTION
## Summary

- Adds `tamboui-toolkit-markdown` dependency to `atunko-tui`
- Splits `DetailView` into two zones: a compact metadata section (name, display name, tags, sub-recipe list, included-in) and a scrollable `MarkdownElement` panel for the description
- OpenRewrite recipe descriptions are CommonMark markdown — headings, code spans, and bullet lists now render correctly instead of as raw text
- Falls back to `*(no description)*` in italic for recipes with no description

## Layout

```
┌─ Detail ─────────────────────────────────────────────────┐
│ Name:         org.openrewrite.java.migrate.UpgradeJava21  │  ← metadata (fixed height)
│ Display Name: Upgrade to Java 21                          │
│ Tags:         java, migration                             │
├───────────────────────────────────────────────────────────┤
│ ## What This Recipe Does                                  │  ← markdown (scrollable fill)
│                                                           │
│ Upgrades your project to **Java 21**, including:          │
│ - Language version update                                 │
│ - `--release 21` compiler flag                            │
└───────────────────────────────────────────────────────────┘
```

## Test plan

- [ ] Open detail view on a recipe with a markdown description — verify headings and inline code render
- [ ] Open detail view on a composite recipe — verify sub-recipe list appears in metadata section
- [ ] Open detail view on a recipe with no description — verify `*(no description)*` renders in italic
- [ ] Scroll long descriptions with arrow keys
- [ ] `Space` still toggles selection; `Esc`/`q` returns to browser