### PR TITLE
chore: add GitHub community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jimisola

--- a/.github/ISSUE_TEMPLATE/00-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug-report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug. Please fill in as much detail as possible.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you submit
+      options:
+        - label: This is a bug report, not a support or usage question
+          required: true
+        - label: I have searched existing issues and no duplicate exists
+          required: true
+        - label: I have read and agree to the [Code of Conduct](https://github.com/atunko-dev/atunko/blob/main/CODE_OF_CONDUCT.md)
+          required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      description: Which part of atunko does this bug affect?
+      options:
+        - atunko-core
+        - atunko-tui
+        - atunko-cli
+        - atunko-web
+        - Other / Multiple
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version of atunko are you using?
+      placeholder: "e.g. 1.2.3"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the actual behaviour you observed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal set of steps to reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. Ubuntu 24.04, macOS 14, Windows 11"
+
+  - type: input
+    id: runtime
+    attributes:
+      label: Java version
+      placeholder: "e.g. Java 21, Java 25"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, or anything else that might help.

--- a/.github/ISSUE_TEMPLATE/10-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/10-feature-request.yml
@@ -1,0 +1,51 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an improvement to atunko!
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you submit
+      options:
+        - label: This is a feature request, not a support or usage question
+          required: true
+        - label: I have searched existing issues and no duplicate exists
+          required: true
+        - label: I have read and agree to the [Code of Conduct](https://github.com/atunko-dev/atunko/blob/main/CODE_OF_CONDUCT.md)
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem description
+      description: What problem does this feature address? Who is affected and in what context?
+      placeholder: "As a user of atunko, I find it difficult to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Desired solution
+      description: Describe the feature or change you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternative solutions or workarounds you have considered.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or references that might help.

--- a/.github/ISSUE_TEMPLATE/90-other.yml
+++ b/.github/ISSUE_TEMPLATE/90-other.yml
@@ -1,0 +1,17 @@
+name: Other
+description: Anything that does not fit the other categories
+labels: ["triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for questions or topics that don't fit the bug report or feature request forms.
+        For general questions, consider using [Discussions](https://github.com/atunko-dev/atunko/discussions) instead.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe your issue or question in as much detail as possible.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Community Support
+    url: https://github.com/atunko-dev/atunko/discussions
+    about: Please ask and answer questions here.

--- a/.github/PULL_REQUEST_TEMPLATE/generic.md
+++ b/.github/PULL_REQUEST_TEMPLATE/generic.md
@@ -1,0 +1,14 @@
+Thank you for helping improve atunko and taking the time to contribute this pull request!
+
+## Description
+
+Please include a summary of the change and which issue is fixed. If no issue exists yet, please create one first.
+
+Fixes #
+
+## Checklist
+
+- [ ] I have reviewed and followed the [contributing guidelines](../CONTRIBUTING.md).
+- [ ] I have run a local build and made sure all tests pass.
+- [ ] I have signed off the [Developer Certificate of Origin](../dco.txt) (`git commit -s`).
+- [ ] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,16 +57,19 @@
       addLabels: ["renovate-version-major"],
       separateMajorMinor: true,
       separateMultipleMajor: true,
+      minimumReleaseAge: "30 days",
     },
     {
       matchUpdateTypes: ["minor"],
       addLabels: ["renovate-version-minor"],
       automerge: true,
+      minimumReleaseAge: "10 days",
     },
     {
       matchUpdateTypes: ["patch"],
       addLabels: ["renovate-version-patch"],
       automerge: true,
+      minimumReleaseAge: "10 days",
     },
     {
       matchUpdateTypes: ["digest"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,138 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  extends: [
+    "config:recommended",
+    ":semanticCommits",
+  ],
+
+  semanticCommits: "enabled",
+  semanticCommitType: "chore",
+  semanticCommitScope: "{{datasource}}",
+
+  automergeType: "pr",
+  platformAutomerge: true,
+
+  branchPrefix: "renovate",
+
+  addLabels: [
+    "bot-renovate",
+  ],
+
+  stopUpdatingLabel: "bot-renovate-stop",
+
+  dependencyDashboard: false,
+
+  prConcurrentLimit: 10,
+  prHourlyLimit: 5,
+
+  lockFileMaintenance: {
+    enabled: true,
+  },
+
+  vulnerabilityAlerts: {
+    enabled: true,
+    addLabels: ["security"],
+  },
+
+  osvVulnerabilityAlerts: true,
+
+  packageRules: [
+
+    // =====================================================
+    // Version constraints
+    // =====================================================
+
+    {
+      matchDepNames: ["java", "openjdk", "temurin"],
+      allowedVersions: "<=25",
+    },
+
+    // =====================================================
+    // Version classification labels
+    // =====================================================
+
+    {
+      matchUpdateTypes: ["major"],
+      addLabels: ["renovate-version-major"],
+      separateMajorMinor: true,
+      separateMultipleMajor: true,
+    },
+    {
+      matchUpdateTypes: ["minor"],
+      addLabels: ["renovate-version-minor"],
+      automerge: true,
+    },
+    {
+      matchUpdateTypes: ["patch"],
+      addLabels: ["renovate-version-patch"],
+      automerge: true,
+    },
+    {
+      matchUpdateTypes: ["digest"],
+      addLabels: ["renovate-version-digest"],
+    },
+
+    // =====================================================
+    // Gradle-specific tuning
+    // =====================================================
+
+    {
+      matchManagers: ["gradle"],
+      matchDepTypes: ["plugin"],
+      groupName: "gradle plugins",
+      addLabels: ["renovate-type-gradle-plugin"],
+    },
+
+    {
+      matchManagers: ["gradle"],
+      matchDatasources: ["java-version"],
+      groupName: "java runtime",
+      addLabels: ["renovate-type-java"],
+    },
+
+    // =====================================================
+    // Ecosystem classification labels
+    // =====================================================
+
+    {
+      matchDatasources: ["docker"],
+      addLabels: ["renovate-type-container"],
+    },
+
+    {
+      matchDatasources: ["java-version", "maven"],
+      addLabels: ["renovate-type-java"],
+    },
+
+    {
+      matchManagers: ["gradle"],
+      addLabels: ["renovate-type-java"],
+    },
+
+    {
+      matchDatasources: ["github-releases", "github-tags"],
+      addLabels: ["renovate-type-cicd"],
+    },
+
+    {
+      matchManagers: ["github-actions"],
+      semanticCommitType: "chore",
+      semanticCommitScope: "github-actions",
+      addLabels: ["renovate-type-cicd"],
+      // GitHub Actions use major version tags (v3 → v4) for routine updates;
+      // auto-merge these when all checks pass.
+      automerge: true,
+    },
+
+    // =====================================================
+    // Generic grouping fallback (MUST BE LAST)
+    // =====================================================
+
+    {
+      matchManagers: ["gradle"],
+      groupName: "{{groupId}} packages",
+      matchPackagePatterns: [".*"],
+    },
+  ],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,9 @@
   semanticCommitType: "chore",
   semanticCommitScope: "{{datasource}}",
 
+  separateMajorMinor: true,
+  separateMultipleMajor: true,
+
   automergeType: "pr",
   platformAutomerge: true,
 
@@ -55,8 +58,6 @@
     {
       matchUpdateTypes: ["major"],
       addLabels: ["renovate-version-major"],
-      separateMajorMinor: true,
-      separateMultipleMajor: true,
       minimumReleaseAge: "30 days",
     },
     {
@@ -135,7 +136,7 @@
     {
       matchManagers: ["gradle"],
       groupName: "{{groupId}} packages",
-      matchPackagePatterns: [".*"],
+      matchPackageNames: ["/.*/"],
     },
   ],
 }

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,16 @@
+enabled: true
+titleAndCommits: true
+
+types:
+  - feat
+  - fix
+  - refactor
+  - chore
+  - security
+  - revert
+  - test
+  - docs
+  - perf
+  - style
+  - ci
+  - build

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -8,7 +8,7 @@ jobs:
   conventional-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - ".github/renovate.json5"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Renovate config

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -1,0 +1,23 @@
+name: Validate Renovate config
+
+on:
+  push:
+    paths:
+      - ".github/renovate.json5"
+  pull_request:
+    paths:
+      - ".github/renovate.json5"
+
+jobs:
+  validate:
+    name: Validate Renovate config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate .github/renovate.json5
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/repo" \
+            renovate/renovate \
+            renovate-config-validator /repo/.github/renovate.json5

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# atunko Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of atunko pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity or expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We are committed to providing a welcoming, professional, and respectful environment for everyone.
+
+---
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Accepting constructive criticism gracefully
+- Focusing on what is best for the community and the project
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior include:
+
+- Harassment, intimidation, or discrimination in any form
+- Trolling, insulting or derogatory comments
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Any conduct which could reasonably be considered inappropriate in a professional setting
+
+---
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and may take appropriate and fair corrective action in response to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned with this Code of Conduct.
+
+---
+
+## Scope
+
+This Code of Conduct applies within all atunko project spaces, including:
+
+- GitHub repositories under the atunko-dev organization
+- Issues and pull requests
+- Discussions
+- Project documentation
+- Any official atunko communication channels
+
+---
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it via GitHub's security reporting feature:
+
+1. Go to the relevant repository
+2. Click on the **Security** tab
+3. Choose **Report a vulnerability**
+
+All reports will be reviewed and handled confidentially and respectfully.
+
+We commit to responding promptly and taking appropriate action.
+
+---
+
+## Enforcement Guidelines
+
+Project maintainers will determine the appropriate response to any incident on a case-by-case basis. Actions may include:
+
+- Warning the individual
+- Temporarily restricting participation
+- Permanent removal from the project community
+
+---
+
+## Attribution
+
+This Code of Conduct is inspired by the Contributor Covenant and adapted for the atunko project.

--- a/cliff.toml
+++ b/cliff.toml
@@ -4,7 +4,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}
-- {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}]({{ commit.remote.link }}/commit/{{ commit.id }}))
+- {{ commit.message | upper_first }}{% if commit.remote.pr_number %} (#{{ commit.remote.pr_number }}){% endif %}
 {% endfor %}
 {% endfor %}
 """


### PR DESCRIPTION
## Summary

- Issue templates (bug report, feature request, other) as form-based YAML with preflight checklists
- Pull request template with DCO sign-off and contributing checklist
- `CODE_OF_CONDUCT.md` adapted from reqstool's for the atunko project
- `.github/CODEOWNERS` assigning `@jimisola` as code owner for all files
- `.github/renovate.json5` for automated dependency updates (Gradle/Java/GitHub Actions; minor/patch/actions auto-merge)
- `.github/semantic.yml` to explicitly configure valid PR title types for `action-semantic-pull-request`
- `cliff.toml`: switch commit links from commit-hash format to `#PR_NUMBER` format
- `check-pr.yml`: bump `action-semantic-pull-request` v5 → v6

Adapted from [reqstool/.github](https://github.com/reqstool/.github).

## Test plan

- [ ] Issue templates render as forms on GitHub (New Issue → see three form-based templates)
- [ ] PR template auto-populates on new PR creation
- [ ] Renovate bot picks up `renovate.json5` and opens a config migration PR if needed
- [ ] `check-pr.yml` passes on this PR (semantic title validated by v6 action)