### PR TITLE
chore(openspec): post-update OpenSpec and reqstool for PRs #56, #57, #59

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,6 @@ Three layers of automated quality checks run on every build:
 
 Requirements and SVCs are tracked via the official reqstool-ai plugin (config: `.reqstool-ai.yaml`).
 Use `/reqstool:add-req`, `/reqstool:add-svc`, `/reqstool:status` for traceability work.
+
+Always create an OpenSpec change (via `/openspec-propose` or manually) **before** making any
+source code changes. Archive it after the PR is merged.

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -781,7 +781,7 @@ public class TuiController {
         }
     }
 
-    @Requirements({"atunko:TUI_0001.14"})
+    @Requirements({"atunko:TUI_0001.14.1"})
     public void flattenAllRunRecipes() {
         if (runState == null) {
             return;
@@ -913,14 +913,14 @@ public class TuiController {
         runConfigService.save(config, file);
     }
 
-    @Requirements({"atunko:TUI_0001.10"})
+    @Requirements({"atunko:TUI_0001.19"})
     public void loadRunConfig(RunConfig config) {
         selectedRecipes.clear();
         config.recipes().stream().map(RecipeEntry::name).forEach(selectedRecipes::add);
         browserState.resetHighlight();
     }
 
-    @Requirements({"atunko:TUI_0001.10"})
+    @Requirements({"atunko:TUI_0001.19"})
     public List<Path> listRunConfigs() {
         Path dir = projectDir.resolve("atunko/runs");
         if (!Files.isDirectory(dir)) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/DetailView.java
@@ -16,7 +16,7 @@ import io.github.atunkodev.tui.TuiController;
 import io.github.reqstool.annotations.Requirements;
 import java.util.List;
 
-@Requirements({"atunko:TUI_0001.4", "atunko:TUI_0001.7"})
+@Requirements({"atunko:TUI_0001.4", "atunko:TUI_0001.7", "atunko:TUI_0001.20"})
 public final class DetailView {
 
     private DetailView() {}

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -373,7 +373,7 @@ class TuiControllerTest {
     // --- Load Run Configuration ---
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.10"})
+    @SVCs({"atunko:SVC_TUI_0001.19"})
     void loadRunConfigRestoresRecipeSelection(@TempDir Path tempDir) throws Exception {
         RunConfigService service = new RunConfigService();
         TuiController controller = new TuiController(RECIPES, service);
@@ -391,7 +391,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.10"})
+    @SVCs({"atunko:SVC_TUI_0001.19.1"})
     void loadRunConfigReplacesExistingSelection(@TempDir Path tempDir) throws Exception {
         RunConfigService service = new RunConfigService();
         TuiController controller = new TuiController(RECIPES, service);
@@ -412,7 +412,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.10"})
+    @SVCs({"atunko:SVC_TUI_0001.19.2"})
     void listRunConfigsReturnsEmptyWhenDirectoryAbsent(@TempDir Path tempDir) {
         TuiController controller = new TuiController(RECIPES, new RunConfigService(), null, null, null, tempDir);
 
@@ -422,7 +422,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.10"})
+    @SVCs({"atunko:SVC_TUI_0001.19.2"})
     void listRunConfigsReturnsYmlFiles(@TempDir Path tempDir) throws Exception {
         RunConfigService service = new RunConfigService();
         TuiController controller = new TuiController(RECIPES, service, null, null, null, tempDir);
@@ -494,7 +494,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.10"})
+    @SVCs({"atunko:SVC_TUI_0001.19"})
     void openLoadConfigSetsScreenAndPopulatesFileList(@TempDir Path tempDir) throws Exception {
         RunConfigService service = new RunConfigService();
         TuiController controller = new TuiController(RECIPES, service, null, null, null, tempDir);
@@ -510,7 +510,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.10"})
+    @SVCs({"atunko:SVC_TUI_0001.19"})
     void confirmLoadConfigLoadsFileAndReturnsToBrowser(@TempDir Path tempDir) throws Exception {
         RunConfigService service = new RunConfigService();
         TuiController controller = new TuiController(RECIPES, service, null, null, null, tempDir);
@@ -766,7 +766,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.14"})
+    @SVCs({"atunko:SVC_TUI_0001.14.1"})
     void flattenAllRunRecipesReplacesAllCompositesWithSubRecipes() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.moveDown(); // highlight Composite
@@ -780,7 +780,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.14"})
+    @SVCs({"atunko:SVC_TUI_0001.14.1"})
     void flattenAllRunRecipesHandlesNestedComposites() {
         TuiController controller = new TuiController(RECIPES_WITH_NESTED);
         // Sorted: Alpha(0), Gamma(1), Outer(2) — highlight Outer
@@ -798,7 +798,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.14"})
+    @SVCs({"atunko:SVC_TUI_0001.14.1"})
     void flattenAllRunRecipesAlreadyFlatListIsUnchanged() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection(); // select Alpha
@@ -813,7 +813,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.14"})
+    @SVCs({"atunko:SVC_TUI_0001.14.1"})
     void flattenAllRunRecipesMixedListFlattensOnlyComposites() {
         TuiController controller = new TuiController(RECIPES_WITH_COMPOSITE);
         controller.toggleSelection(); // select Alpha
@@ -829,7 +829,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.14"})
+    @SVCs({"atunko:SVC_TUI_0001.14.1"})
     void flattenAllRunRecipesDeduplicatesSharedLeaves() {
         // Two composites sharing Sub1 — flattening both should produce Sub1 only once
         RecipeInfo shared = new RecipeInfo("org.test.Shared", "Shared", "Shared leaf", Set.of());
@@ -851,7 +851,7 @@ class TuiControllerTest {
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.14"})
+    @SVCs({"atunko:SVC_TUI_0001.14.1"})
     void flattenAllRunRecipesMultipleLeafListIsUnchanged() {
         TuiController controller = new TuiController(RECIPES);
         controller.toggleSelection(); // select Alpha (leaf)

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/view/DetailViewTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/view/DetailViewTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
-@SVCs({"atunko:SVC_TUI_0001.4"})
+@SVCs({"atunko:SVC_TUI_0001.20"})
 class DetailViewTest {
 
     private static final RecipeInfo LEAF =
@@ -20,35 +20,35 @@ class DetailViewTest {
             "org.test.Composite", "Composite Recipe", "A composite", Set.of(), List.of(SUB_1, SUB_2, SUB_3));
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.4"})
+    @SVCs({"atunko:SVC_TUI_0001.20"})
     void metadataLineCountLeafNoParents() {
         // 4 base + 1 buffer = 5
         assertThat(DetailView.metadataLineCount(LEAF, 0)).isEqualTo(5);
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.4"})
+    @SVCs({"atunko:SVC_TUI_0001.20"})
     void metadataLineCountLeafWithParents() {
         // 4 base + 2 (blank + included-in row) + 1 buffer = 7
         assertThat(DetailView.metadataLineCount(LEAF, 2)).isEqualTo(7);
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.4"})
+    @SVCs({"atunko:SVC_TUI_0001.20"})
     void metadataLineCountCompositeNoParents() {
         // 4 base + 2 (blank + "Recipe List:" label) + 3 sub-recipes + 1 buffer = 10
         assertThat(DetailView.metadataLineCount(COMPOSITE, 0)).isEqualTo(10);
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.4"})
+    @SVCs({"atunko:SVC_TUI_0001.20"})
     void metadataLineCountCompositeWithParents() {
         // 4 base + 2 + 3 subs + 2 (blank + included-in) + 1 buffer = 12
         assertThat(DetailView.metadataLineCount(COMPOSITE, 1)).isEqualTo(12);
     }
 
     @Test
-    @SVCs({"atunko:SVC_TUI_0001.4"})
+    @SVCs({"atunko:SVC_TUI_0001.20"})
     void metadataLineCountBufferIsAlwaysPresent() {
         int withoutParents = DetailView.metadataLineCount(LEAF, 0);
         int withParents = DetailView.metadataLineCount(LEAF, 1);

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -349,6 +349,17 @@ requirements:
     categories: [interaction-capability]
     revision: 0.1.0
 
+  - id: TUI_0001.14.1
+    title: TUI — Run Dialog Flatten-All
+    significance: shall
+    description: >-
+      The TUI run dialog shall support flattening all composite recipes to their
+      leaf constituents in a single operation, deduplicating any shared leaves
+    references:
+      requirement_ids: ["TUI_0001.14"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
   - id: TUI_0001.15
     title: TUI — Debug Logging
     significance: shall
@@ -391,6 +402,28 @@ requirements:
       The TUI shall support CSS-based theming via TamboUI TCSS stylesheets,
       shipping bundled dark and light themes, with user-provided CSS file support
       and theme selection via --theme CLI flag
+    references:
+      requirement_ids: ["TUI_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: TUI_0001.19
+    title: TUI — Load Run Config
+    significance: shall
+    description: >-
+      The TUI shall support loading a previously saved run configuration from an
+      atunko/runs/*.yml file, replacing the current recipe selection
+    references:
+      requirement_ids: ["TUI_0001"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: TUI_0001.20
+    title: TUI — Markdown Recipe Descriptions
+    significance: shall
+    description: >-
+      The TUI detail view shall render recipe descriptions as formatted markdown
+      using the tamboui-toolkit-markdown library
     references:
       requirement_ids: ["TUI_0001"]
     categories: [interaction-capability]

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -579,6 +579,16 @@ cases:
       THEN the execution order and selection state update accordingly
     revision: "0.1.0"
 
+  - id: SVC_TUI_0001.14.1
+    requirement_ids: ["TUI_0001.14.1"]
+    title: Flatten-all replaces all composites with leaf recipes
+    verification: automated-test
+    description: |
+      GIVEN the run dialog contains one or more composite recipes
+      WHEN the user triggers flatten-all
+      THEN all composites are replaced by their leaf constituents, with shared leaves deduplicated
+    revision: "0.1.0"
+
   - id: SVC_TUI_0001.15
     requirement_ids: ["TUI_0001.15"]
     title: Debug logging to file
@@ -707,6 +717,46 @@ cases:
       GIVEN the TUI is launched with --theme dark or --theme light
       WHEN the StyleEngine is initialized
       THEN the corresponding bundled theme stylesheet is loaded
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.19
+    requirement_ids: ["TUI_0001.19"]
+    title: Load config restores recipe selection
+    verification: automated-test
+    description: |
+      GIVEN a saved run configuration file
+      WHEN the user loads the configuration
+      THEN the current recipe selection is replaced with the saved selection
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.19.1
+    requirement_ids: ["TUI_0001.19"]
+    title: Load config replaces existing selection
+    verification: automated-test
+    description: |
+      GIVEN recipes are already selected
+      WHEN the user loads a different run configuration
+      THEN the previous selection is cleared and replaced with the loaded selection
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.19.2
+    requirement_ids: ["TUI_0001.19"]
+    title: List run configs returns available yml files
+    verification: automated-test
+    description: |
+      GIVEN the atunko/runs/ directory contains .yml files
+      WHEN the load config screen is opened
+      THEN all .yml files are listed for selection
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.20
+    requirement_ids: ["TUI_0001.20"]
+    title: Detail view renders recipe descriptions as markdown
+    verification: automated-test
+    description: |
+      GIVEN a recipe with a markdown description
+      WHEN the detail view is displayed
+      THEN the description is rendered as formatted markdown
     revision: "0.1.0"
 
   - id: SVC_CLI_0002

--- a/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/design.md
+++ b/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/design.md
@@ -1,0 +1,42 @@
+## Context
+
+The TUI run dialog (`ConfirmRunView`) already had a single-composite flatten (`f` key) backed
+by `TuiController.flattenRunRecipe()`. Flatten-all is a superset: keep flattening until the
+run order contains only leaf recipes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Single keypress (`F`) to recursively flatten all composites in the run order
+- Deduplicate leaves that appear in more than one composite (preserve first-seen order)
+- Update help text and help overlay to document both flatten modes
+
+**Non-Goals:**
+- Auto-flatten on dialog open
+- Undo/redo
+
+## Decisions
+
+### Loop-until-stable algorithm
+
+**Rationale:** Nested composites (a composite whose sub-recipe is itself composite) require
+multiple passes. A `while (changed)` loop is the simplest correct approach; in practice
+recipe nesting rarely exceeds 2–3 levels so performance is not a concern.
+
+### `LinkedHashSet` for deduplication
+
+**Rationale:** Preserves insertion order while eliminating duplicate leaf names that arise
+when two composites share a sub-recipe. A plain `List` + `contains` check would also work
+but is O(n²) on large lists; `LinkedHashSet` is O(n).
+
+### `F` key binding (uppercase)
+
+**Rationale:** Consistent with the existing convention of `f` for single-flatten, uppercase
+for the "more powerful" variant (also consistent with `F` for "flatten-all" in the Web UI
+run order dialog).
+
+## Risks / Trade-offs
+
+- If a composite's sub-recipe is not in `allRecipes` (unlikely but possible with partial
+  classpath scans), `findRecipeDeep` returns empty and the name is kept as-is rather than
+  crashing. Acceptable conservative behaviour.

--- a/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/proposal.md
+++ b/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The TUI run dialog already supported flattening a single highlighted composite recipe
+(press `f`). Users with multiple composites in their run order had to flatten them one
+by one, which was tedious. A "flatten all" operation covers the common case of
+wanting fully-resolved leaf recipes before executing.
+
+## What Changes
+
+- Add `flattenAllRunRecipes()` to `TuiController`: iterates the run order until no
+  composites remain, deduplicating shared leaves via `LinkedHashSet`
+- Bind the `F` (uppercase) key in `ConfirmRunView` to trigger flatten-all
+- Update `HelpOverlay` CONFIRM_RUN section to document `f:flatten F:flatten-all`
+
+## Capabilities
+
+### New Capabilities
+
+- `tui-flatten-all-composites`: Single-keystroke flatten of all composites in the run
+  order, with shared-leaf deduplication (TUI_0001.14.1)
+
+### Modified Capabilities
+
+- `tui-launch`: The run dialog footer hint text and help overlay are updated to document
+  both flatten modes
+
+## Impact
+
+- `atunko-tui`: `TuiController.java` (+51 lines), `ConfirmRunView.java` (+8 lines),
+  `HelpOverlay.java` (+15 lines), `TuiControllerTest.java` (+100 lines of new tests)
+- No breaking changes — the existing `f` flatten-one behaviour is unchanged

--- a/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/specs/spec.md
+++ b/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/specs/spec.md
@@ -1,0 +1,7 @@
+## ADDED Requirements
+
+### Requirement: TUI_0001.14.1
+The system SHALL implement TUI_0001.14.1.
+
+#### Scenario: SVC_TUI_0001.14.1
+The system SHALL pass SVC_TUI_0001.14.1.

--- a/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/tasks.md
+++ b/openspec/changes/archive/2026-05-17-tui-flatten-all-composites/tasks.md
@@ -1,0 +1,34 @@
+## 1. reqstool — Requirements & SVCs
+
+- [x] 1.1 Add TUI_0001.14.1 (TUI — Run Dialog Flatten-All) to `docs/reqstool/requirements.yml`
+      as a child of TUI_0001.14
+- [x] 1.2 Add SVC_TUI_0001.14.1 to `docs/reqstool/software_verification_cases.yml`
+
+## 2. Implementation (TUI_0001.14.1)
+
+- [x] 2.1 Implement `flattenAllRunRecipes()` in `TuiController` with loop-until-stable algorithm
+      using `LinkedHashSet` for deduplication
+- [x] 2.2 Add `@Requirements({"atunko:TUI_0001.14.1"})` to `flattenAllRunRecipes()`
+- [x] 2.3 Add `F` key handler in `ConfirmRunView` to call `flattenAllRunRecipes()`
+- [x] 2.4 Update footer hint text to `f:flatten F:flatten-all ?:help`
+- [x] 2.5 Update `HelpOverlay` CONFIRM_RUN section to document both flatten keys
+
+## 3. Tests (SVC_TUI_0001.14.1)
+
+- [x] 3.1 Write `flattenAllRunRecipesReplacesAllCompositesWithSubRecipes`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.14.1"})`
+- [x] 3.2 Write `flattenAllRunRecipesHandlesNestedComposites`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.14.1"})`
+- [x] 3.3 Write `flattenAllRunRecipesAlreadyFlatListIsUnchanged`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.14.1"})`
+- [x] 3.4 Write `flattenAllRunRecipesMixedListFlattensOnlyComposites`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.14.1"})`
+- [x] 3.5 Write `flattenAllRunRecipesDeduplicatesSharedLeaves`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.14.1"})`
+- [x] 3.6 Write `flattenAllRunRecipesMultipleLeafListIsUnchanged`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.14.1"})`
+
+## 4. Build & Verification
+
+- [x] 4.1 Run `./gradlew spotlessApply` to fix formatting
+- [x] 4.2 Run `./gradlew build` — all checks pass

--- a/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/design.md
+++ b/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/design.md
@@ -1,0 +1,36 @@
+## Context
+
+The TUI detail view renders a full-screen panel for the highlighted recipe. The description
+field, authored as markdown by OpenRewrite recipe maintainers, was displayed as raw text.
+The `tamboui-toolkit-markdown` toolkit library provides a `markdown()` element that renders
+CommonMark inside a TUI dock slot.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render `recipe.description()` as formatted markdown in the centre of the detail panel
+- Extract a testable `metadataLineCount()` helper to fix the top-panel height so the
+  markdown region gets a stable centre slot
+
+**Non-Goals:**
+- Custom markdown extensions (code highlighting, tables)
+- Fallback rendering for terminals without ANSI support (handled by TamboUI)
+
+## Decisions
+
+### Use `tamboui-toolkit-markdown`
+
+**Rationale:** The dependency is provided by TamboUI's own toolkit — it is the idiomatic
+choice for the framework, avoids pulling in a separate CommonMark library, and keeps the
+rendering behaviour consistent with any future TamboUI-rendered markdown in the app.
+
+### Extract `metadataLineCount()` as a package-private static method
+
+**Rationale:** The top panel must have a fixed `Constraint.length(n)` so the markdown
+element's `dock().center()` slot has room. Extracting the calculation as a static method
+makes it independently testable without spinning up the full TUI.
+
+## Risks / Trade-offs
+
+- **TamboUI markdown dependency**: If TamboUI drops or renames the module the import
+  breaks. Low risk — the toolkit is maintained in lock-step with the core library.

--- a/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/proposal.md
+++ b/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Recipe descriptions in the TUI detail view were displayed as plain text, losing all
+formatting that recipe authors intended (bold, code spans, lists). The `tamboui-toolkit-markdown`
+library makes it straightforward to render markdown natively in TUI panels.
+
+## What Changes
+
+- Add `tamboui-toolkit-markdown` dependency to `atunko-tui`
+- Refactor `DetailView` to extract `metadataLineCount()` helper so the top panel has a
+  known height, leaving the centre region for the markdown-rendered description
+- Render the description via `markdown(description)` in a `dock().center()` slot
+
+## Capabilities
+
+### New Capabilities
+
+- `tui-markdown-descriptions`: The TUI detail view renders recipe descriptions as formatted
+  markdown (TUI_0001.20)
+
+### Modified Capabilities
+
+- `tui-launch`: The detail view layout is restructured to use a fixed-height metadata top
+  panel and a markdown description centre panel
+
+## Impact
+
+- `atunko-tui`: `DetailView.java` (refactored + markdown), `DetailViewTest.java` (new tests
+  for `metadataLineCount`), `build.gradle` (+1 dependency), `gradle/libs.versions.toml` (+1 entry)
+- No breaking changes — purely visual enhancement within the TUI detail screen

--- a/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/specs/spec.md
+++ b/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/specs/spec.md
@@ -1,0 +1,7 @@
+## ADDED Requirements
+
+### Requirement: TUI_0001.20
+The system SHALL implement TUI_0001.20.
+
+#### Scenario: SVC_TUI_0001.20
+The system SHALL pass SVC_TUI_0001.20.

--- a/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/tasks.md
+++ b/openspec/changes/archive/2026-05-17-tui-markdown-descriptions/tasks.md
@@ -1,0 +1,25 @@
+## 1. reqstool — Requirements & SVCs
+
+- [x] 1.1 Add TUI_0001.20 (TUI — Markdown Recipe Descriptions) to `docs/reqstool/requirements.yml`
+- [x] 1.2 Add SVC_TUI_0001.20 to `docs/reqstool/software_verification_cases.yml`
+
+## 2. Dependency
+
+- [x] 2.1 Add `tamboui-toolkit-markdown` to `gradle/libs.versions.toml` and `atunko-tui/build.gradle`
+
+## 3. Implementation (TUI_0001.20)
+
+- [x] 3.1 Extract `metadataLineCount(RecipeInfo, int)` as package-private static method in `DetailView`
+- [x] 3.2 Add `@Requirements({"atunko:TUI_0001.20"})` to `DetailView` class annotation
+- [x] 3.3 Replace plain-text description rendering with `markdown(description)` in `dock().center()`
+- [x] 3.4 Use `metadataLineCount()` for the top panel `Constraint.length(n)`
+
+## 4. Tests (SVC_TUI_0001.20)
+
+- [x] 4.1 Write `DetailViewTest` covering `metadataLineCount` for leaf/composite with/without parents
+- [x] 4.2 Annotate all `DetailViewTest` methods with `@SVCs({"atunko:SVC_TUI_0001.20"})`
+
+## 5. Build & Verification
+
+- [x] 5.1 Run `./gradlew spotlessApply` to fix formatting
+- [x] 5.2 Run `./gradlew build` — all checks pass

--- a/openspec/changes/archive/2026-05-17-tui-save-load-run-config/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-17-tui-save-load-run-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-17-tui-save-load-run-config/design.md
+++ b/openspec/changes/archive/2026-05-17-tui-save-load-run-config/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The core `RunConfigService` (CORE_0007 / CORE_0008) and Web UI save/load (WEB_0001.11 /
+WEB_0001.12) were already complete. The TUI needed a UI layer on top of the existing service:
+a save-mode inline text input in the browser and a dedicated `LOAD_CONFIG` screen.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Save: press `S` in the browser, type a name, Enter to write `atunko/runs/<name>.yml`
+- Load: press `L` to open a file picker screen, navigate with j/k, Enter to load
+- Blank name on save silently cancels (no empty files created)
+- Empty runs directory shows an empty list (no crash)
+
+**Non-Goals:**
+- Delete / rename saved configs (future work)
+- Config validation beyond what `RunConfigService` provides
+
+## Decisions
+
+### Inline save-mode text input in `BrowserView`
+
+**Rationale:** Keeps the user on the same screen without a modal. The save-mode state
+(`isSaveConfigMode`, `saveConfigName`) is held in `TuiController` so `BrowserView` stays
+stateless. `Toolkit.handleTextInputKey` handles character input and backspace uniformly.
+
+### Dedicated `LoadConfigView` screen (new `Screen.LOAD_CONFIG`)
+
+**Rationale:** The load flow needs a scrollable list of files — reusing the browser for
+this would require complex temporary state. A dedicated lightweight screen (no focusable
+sub-elements, single key handler) is simpler and consistent with `ExecutionResultsView`.
+
+### Files stored under `atunko/runs/` relative to `projectDir`
+
+**Rationale:** Keeps all atunko artefacts in one place, co-located with the project so
+they can be version-controlled alongside the code.
+
+## Risks / Trade-offs
+
+- **`projectDir` at construction time**: `TuiController` resolves `projectDir` on
+  construction. If the user changes project mid-session (future multi-project work) the
+  runs path won't update automatically. Acceptable for now; multi-project support is a
+  separate change.

--- a/openspec/changes/archive/2026-05-17-tui-save-load-run-config/proposal.md
+++ b/openspec/changes/archive/2026-05-17-tui-save-load-run-config/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The core module already provided `RunConfigService` for saving and loading run
+configurations (CORE_0007 / CORE_0008), and the Web UI exposed both via WEB_0001.11 /
+WEB_0001.12. The TUI only had the save capability (TUI_0001.10) defined — the UI
+implementation and the load workflow were missing, leaving TUI users without a way to
+persist or restore their recipe selections.
+
+## What Changes
+
+- Add save workflow to `BrowserView`: press `S` to enter save-mode with an inline text
+  input, Enter to confirm, Esc to cancel
+- Add load workflow: press `L` to open a new `LOAD_CONFIG` screen (`LoadConfigView`)
+  listing `atunko/runs/*.yml` files, navigate with j/k, confirm with Enter
+- Extend `TuiController` with save/load state machine methods:
+  `saveRunConfig`, `loadRunConfig`, `listRunConfigs`, `openLoadConfig`,
+  `confirmLoadConfig`, `enterSaveConfigMode`, `exitSaveConfigMode`,
+  `setSaveConfigName`, `confirmSaveConfig`
+- New `LoadConfigView` screen
+- Update `HelpOverlay` BROWSER section to document `S` and `L` keys
+
+## Capabilities
+
+### New Capabilities
+
+- `tui-load-run-config`: Browse and load saved run configurations from the TUI (TUI_0001.19)
+
+### Modified Capabilities
+
+- `tui-save-run-config`: TUI save workflow implemented with inline text input (TUI_0001.10)
+
+## Impact
+
+- `atunko-tui`: `TuiController.java` (+93 lines), `BrowserView.java` (+47 lines),
+  `HelpOverlay.java` (+2 lines), `Screen.java` (+1 enum value), `AtunkoTui.java` (+2 lines),
+  `LoadConfigView.java` (new, 86 lines), `TuiControllerTest.java` (+181 lines of new tests)
+- Reuses `RunConfigService` from `atunko-core` — no core changes needed

--- a/openspec/changes/archive/2026-05-17-tui-save-load-run-config/specs/spec.md
+++ b/openspec/changes/archive/2026-05-17-tui-save-load-run-config/specs/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: TUI_0001.19
+The system SHALL implement TUI_0001.19.
+
+#### Scenario: SVC_TUI_0001.19
+The system SHALL pass SVC_TUI_0001.19.
+
+#### Scenario: SVC_TUI_0001.19.1
+The system SHALL pass SVC_TUI_0001.19.1.
+
+#### Scenario: SVC_TUI_0001.19.2
+The system SHALL pass SVC_TUI_0001.19.2.
+
+## MODIFIED Requirements
+
+### Requirement: TUI_0001.10
+The system SHALL implement TUI_0001.10.
+
+#### Scenario: SVC_TUI_0001.10
+The system SHALL pass SVC_TUI_0001.10.

--- a/openspec/changes/archive/2026-05-17-tui-save-load-run-config/tasks.md
+++ b/openspec/changes/archive/2026-05-17-tui-save-load-run-config/tasks.md
@@ -1,0 +1,60 @@
+## 1. reqstool — Requirements & SVCs
+
+- [x] 1.1 Add TUI_0001.19 (TUI — Load Run Config) to `docs/reqstool/requirements.yml`
+- [x] 1.2 Add SVC_TUI_0001.19, SVC_TUI_0001.19.1, SVC_TUI_0001.19.2 to
+      `docs/reqstool/software_verification_cases.yml`
+
+## 2. Screen & Navigation
+
+- [x] 2.1 Add `LOAD_CONFIG` value to `Screen` enum in `AtunkoTui` switch
+- [x] 2.2 Create `LoadConfigView` — list files, j/k navigation, Enter/Esc handling
+
+## 3. TuiController — Save workflow (TUI_0001.10)
+
+- [x] 3.1 Implement `saveRunConfig(Path)` and annotate `@Requirements({"atunko:TUI_0001.10"})`
+- [x] 3.2 Implement `enterSaveConfigMode()`, `exitSaveConfigMode()`, `setSaveConfigName()`,
+      `confirmSaveConfig()`
+- [x] 3.3 Add `S` key handler in `BrowserView` to enter save-mode with inline text input
+
+## 4. TuiController — Load workflow (TUI_0001.19)
+
+- [x] 4.1 Implement `loadRunConfig(RunConfig)` and annotate `@Requirements({"atunko:TUI_0001.19"})`
+- [x] 4.2 Implement `listRunConfigs()` and annotate `@Requirements({"atunko:TUI_0001.19"})`
+- [x] 4.3 Implement `openLoadConfig()`, `confirmLoadConfig()`, `moveLoadConfigDown()`,
+      `moveLoadConfigUp()`
+- [x] 4.4 Add `L` key handler in `BrowserView` to call `openLoadConfig()`
+
+## 5. Help Overlay
+
+- [x] 5.1 Update `HelpOverlay` BROWSER section to document `S: Save run config` and
+      `L: Load run config`
+
+## 6. Tests — Save (SVC_TUI_0001.10)
+
+- [x] 6.1 Write `saveRunConfigPersistsSelectedRecipes` annotated `@SVCs({"atunko:SVC_TUI_0001.10"})`
+- [x] 6.2 Write `confirmSaveConfigWritesFileUnderProjectDir`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.10"})`
+- [x] 6.3 Write `confirmSaveConfigWithBlankNameExitsWithoutSaving`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.10"})`
+- [x] 6.4 Write `enterSaveConfigModeSetsModeFlag` annotated `@SVCs({"atunko:SVC_TUI_0001.10"})`
+- [x] 6.5 Write `exitSaveConfigModeClearsFlag` annotated `@SVCs({"atunko:SVC_TUI_0001.10"})`
+
+## 7. Tests — Load (SVC_TUI_0001.19 / 19.1 / 19.2)
+
+- [x] 7.1 Write `loadRunConfigRestoresRecipeSelection`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.19"})`
+- [x] 7.2 Write `loadRunConfigReplacesExistingSelection`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.19.1"})`
+- [x] 7.3 Write `listRunConfigsReturnsEmptyWhenDirectoryAbsent`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.19.2"})`
+- [x] 7.4 Write `listRunConfigsReturnsYmlFiles`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.19.2"})`
+- [x] 7.5 Write `openLoadConfigSetsScreenAndPopulatesFileList`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.19"})`
+- [x] 7.6 Write `confirmLoadConfigLoadsFileAndReturnsToBrowser`
+      annotated `@SVCs({"atunko:SVC_TUI_0001.19"})`
+
+## 8. Build & Verification
+
+- [x] 8.1 Run `./gradlew spotlessApply` to fix formatting
+- [x] 8.2 Run `./gradlew build` — all checks pass


### PR DESCRIPTION
## Summary

- Retroactively creates three archived OpenSpec changes for PRs that were merged without OpenSpec artifacts: #56 (flatten-all composites), #57 (save/load run config), #59 (markdown descriptions)
- Adds new reqstool requirements (`TUI_0001.14.1`, `TUI_0001.19`, `TUI_0001.20`) and SVCs to match the implemented behaviour
- Fixes `@Requirements` and `@SVCs` annotations in source/test files that were pointing to overly-broad IDs
- Adds rule to `CLAUDE.md` to always create an OpenSpec change before touching source code

## Changes per PR

| PR | OpenSpec change | New requirement(s) | New SVC(s) |
|----|----------------|--------------------|-----------|
| #59 | `tui-markdown-descriptions` | `TUI_0001.20` | `SVC_TUI_0001.20` |
| #56 | `tui-flatten-all-composites` | `TUI_0001.14.1` | `SVC_TUI_0001.14.1` |
| #57 | `tui-save-load-run-config` | `TUI_0001.19` | `SVC_TUI_0001.19`, `.19.1`, `.19.2` |

## Test plan

- [x] `./gradlew build` passes (all tests, Spotless, Checkstyle, Error Prone)