### PR TITLE
fix(tui): annotate theming implementation with TUI_0001.18

### DIFF
--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
@@ -83,6 +83,7 @@ public class AtunkoTui extends ToolkitApp {
         quit();
     }
 
+    @Requirements({"atunko:TUI_0001.18"})
     private StyleEngine createStyleEngine() throws IOException {
         StyleEngine engine = StyleEngine.create();
         if (themeConfig.isUserCss()) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/ThemeConfig.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/ThemeConfig.java
@@ -1,5 +1,6 @@
 package io.github.atunkodev.tui;
 
+import io.github.reqstool.annotations.Requirements;
 import java.nio.file.Path;
 
 /**
@@ -27,6 +28,7 @@ public record ThemeConfig(String themeName, Path cssFile) {
      *   <li>Default — dark theme</li>
      * </ol>
      */
+    @Requirements({"atunko:TUI_0001.18"})
     public static ThemeConfig resolve(String themeName, Path cssFile) {
         return resolve(themeName, cssFile, XDG_THEME_PATH);
     }


### PR DESCRIPTION
## Summary

- Adds `@Requirements({"atunko:TUI_0001.18"})` to `ThemeConfig.resolve()` — the entry point for resolving `--theme`/`--css-file`/XDG auto-load
- Adds `@Requirements({"atunko:TUI_0001.18"})` to `AtunkoTui.createStyleEngine()` — applies the resolved theme to the StyleEngine
- Adds missing `import io.github.reqstool.annotations.Requirements` to `ThemeConfig.java`

**Why:** reqstool reported 0 implementations for `TUI_0001.18` despite all 9 SVCs (`SVC_TUI_0001.18` through `SVC_TUI_0001.18.4`) passing. The theming behaviour was implemented in PR #60 (`feat/tui-css-theming`) but the `@Requirements` traceability annotations were never added to the implementing methods.

## Test plan

- [x] `./gradlew build` passes (all tests green, Spotless, Checkstyle, Error Prone)
- [x] `reqstool status local -p atunko-tui/docs/reqstool` shows `TUI_0001.18` with 2 implementations and 9/9 SVCs passing