### PR TITLE
feat(cli): launch TUI by default when no subcommand is given (#7)

### DIFF
--- a/atunko-cli/src/main/java/io/github/atunkodev/App.java
+++ b/atunko-cli/src/main/java/io/github/atunkodev/App.java
@@ -8,6 +8,7 @@ import io.github.atunkodev.cli.SearchCommand;
 import io.github.atunkodev.cli.ServiceFactory;
 import io.github.atunkodev.tui.TuiCommand;
 import io.github.atunkodev.web.WebUiCommand;
+import io.github.reqstool.annotations.Requirements;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
@@ -31,9 +32,9 @@ public class App implements Runnable {
     private CommandSpec spec;
 
     @Override
+    @Requirements({"atunko:CLI_0001"})
     public void run() {
-        // Default: print usage (TUI launch deferred to CLI_0001)
-        spec.commandLine().usage(spec.commandLine().getOut());
+        spec.commandLine().getSubcommands().get("tui").execute();
     }
 
     public static void main(String[] args) {

--- a/atunko-cli/src/test/java/io/github/atunkodev/AppTest.java
+++ b/atunko-cli/src/test/java/io/github/atunkodev/AppTest.java
@@ -3,6 +3,7 @@ package io.github.atunkodev;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.atunkodev.testing.CommandLineFixture;
+import io.github.reqstool.annotations.SVCs;
 import org.junit.jupiter.api.Test;
 
 class AppTest {
@@ -21,12 +22,10 @@ class AppTest {
     }
 
     @Test
-    void noArgsPrintsUsage() {
+    @SVCs({"atunko:SVC_CLI_0001"})
+    void tuiSubcommandIsRegistered() {
         CommandLineFixture cli = CommandLineFixture.create();
 
-        int exitCode = cli.execute();
-
-        assertThat(exitCode).isZero();
-        assertThat(cli.stdout()).contains("atunko");
+        assertThat(cli.cmd().getSubcommands()).containsKey("tui");
     }
 }

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -448,6 +448,15 @@ requirements:
     revision: 0.1.0
 
   # CLI requirements — list/search/run
+  - id: CLI_0001
+    title: CLI Default Behaviour — Launch TUI
+    significance: shall
+    description: >-
+      When the tool is invoked without a subcommand, it shall launch the interactive TUI
+      (equivalent to running `atunko tui`)
+    categories: [functional-suitability]
+    revision: 0.1.0
+
   - id: CLI_0002
     title: CLI Recipe Listing
     significance: shall

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -809,6 +809,16 @@ cases:
       THEN the description is rendered as formatted markdown
     revision: "0.1.0"
 
+  - id: SVC_CLI_0001
+    requirement_ids: ["CLI_0001"]
+    title: No-args invocation delegates to TUI subcommand
+    verification: automated-test
+    description: |
+      GIVEN the atunko CLI is configured
+      WHEN no subcommand is provided
+      THEN the "tui" subcommand is registered and is the delegation target for the default run() path
+    revision: "0.1.0"
+
   - id: SVC_CLI_0002
     requirement_ids: ["CLI_0002"]
     title: List recipes via CLI

--- a/openspec/changes/archive/2026-05-19-tui-default-cli-7/design.md
+++ b/openspec/changes/archive/2026-05-19-tui-default-cli-7/design.md
@@ -1,0 +1,38 @@
+## Context
+
+`App` is the Picocli root command in `atunko-cli`. When invoked with no arguments, Picocli
+calls `App.run()`. Previously this printed usage. The TUI (`atunko tui`) is the primary
+interface; printing usage as the default is a poor UX.
+
+Picocli 4.7.7 (the version on the classpath) does not expose `setDefaultCommandName()` —
+that method does not exist. The only available delegation path from `App.run()` is via
+`spec.commandLine().getSubcommands().get("tui").execute()`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `atunko` (no args) launches the TUI, identical to `atunko tui`
+- `atunko --help` still prints root-level usage (unchanged — Picocli handles `--help` before `run()`)
+
+**Non-Goals:**
+- Propagating the TUI's exit code from `App.run()` (Picocli `Runnable.run()` is void; TUI exits with 0 on normal close)
+- Mouse support, sorting, or any other TUI feature
+
+## Decisions
+
+**Delegate via `getSubcommands().get("tui").execute()` instead of `setDefaultCommandName()`**
+Picocli 4.7.7 does not have `setDefaultCommandName`. Calling the subcommand's `execute()`
+from `App.run()` is the idiomatic fallback: Picocli has already wired the factory and all
+dependencies, so the subcommand executes with full context.
+
+**Test verifies registration, not execution**
+Launching TUI in a headless test environment is not possible (requires a real TTY). The
+test instead asserts that "tui" is registered in `cmd.getSubcommands()`, which is the
+necessary precondition for the delegation to succeed at runtime.
+
+## Risks / Trade-offs
+
+- **Exit code not propagated**: If TUI exits non-zero, `App.run()` still returns normally
+  and Picocli reports exit code 0. Acceptable — TUI closes cleanly on `q`/`Esc` with code 0.
+- **Headless test gap**: The delegation path itself is not exercised under test. The
+  registration check is a proxy. → Mitigation: manual smoke test (`./gradlew :atunko-cli:run`).

--- a/openspec/changes/archive/2026-05-19-tui-default-cli-7/proposal.md
+++ b/openspec/changes/archive/2026-05-19-tui-default-cli-7/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Running `atunko` without a subcommand printed the help/usage text — not useful as a default
+UX since the TUI is the primary interface. Issue #7 requires the bare `atunko` invocation
+to launch the TUI directly, the same as `atunko tui`.
+
+## What Changes
+
+- `App.run()` delegates to the registered "tui" subcommand via
+  `spec.commandLine().getSubcommands().get("tui").execute()` instead of printing usage
+- `@Requirements({"atunko:CLI_0001"})` added to `App.run()`
+- `AppTest.noArgsPrintsUsage` replaced by `tuiSubcommandIsRegistered` — verifies "tui" is
+  the registered subcommand the default path delegates to (TUI cannot be launched headlessly)
+
+## Capabilities
+
+### New Capabilities
+
+- `cli-default-tui`: Invoking `atunko` without arguments launches the interactive TUI
+
+## Impact
+
+- `atunko-cli`: `App` — one-line change to `run()`; new `CLI_0001` requirement added
+- `atunko-cli` tests: `AppTest` — one test replaced
+- `docs/reqstool/requirements.yml`: new `CLI_0001`
+- `docs/reqstool/software_verification_cases.yml`: new `SVC_CLI_0001`
+- No core, TUI, or web changes

--- a/openspec/changes/archive/2026-05-19-tui-default-cli-7/specs/cli-default-tui/spec.md
+++ b/openspec/changes/archive/2026-05-19-tui-default-cli-7/specs/cli-default-tui/spec.md
@@ -1,0 +1,7 @@
+## ADDED Requirements
+
+### Requirement: CLI_0001
+The system SHALL implement CLI_0001.
+
+#### Scenario: SVC_CLI_0001
+The system SHALL pass SVC_CLI_0001.

--- a/openspec/changes/archive/2026-05-19-tui-default-cli-7/tasks.md
+++ b/openspec/changes/archive/2026-05-19-tui-default-cli-7/tasks.md
@@ -1,0 +1,17 @@
+## 1. Requirements & SVCs
+
+- [x] 1.1 Add `CLI_0001` requirement to `docs/reqstool/requirements.yml`
+- [x] 1.2 Add `SVC_CLI_0001` to `docs/reqstool/software_verification_cases.yml`
+
+## 2. App — Default Delegation
+
+- [x] 2.1 Change `App.run()` to call `spec.commandLine().getSubcommands().get("tui").execute()`
+- [x] 2.2 Add `@Requirements({"atunko:CLI_0001"})` to `App.run()`
+
+## 3. Tests
+
+- [x] 3.1 Replace `noArgsPrintsUsage` with `tuiSubcommandIsRegistered` — asserts `cmd.getSubcommands()` contains key `"tui"`; annotate with `@SVCs({"atunko:SVC_CLI_0001"})`
+
+## 4. Quality
+
+- [x] 4.1 Run `./gradlew spotlessApply && ./gradlew :atunko-cli:test` — all tests pass, no violations

--- a/openspec/changes/tui-default-cli-7/design.md
+++ b/openspec/changes/tui-default-cli-7/design.md
@@ -1,0 +1,38 @@
+## Context
+
+`App` is the Picocli root command in `atunko-cli`. When invoked with no arguments, Picocli
+calls `App.run()`. Previously this printed usage. The TUI (`atunko tui`) is the primary
+interface; printing usage as the default is a poor UX.
+
+Picocli 4.7.7 (the version on the classpath) does not expose `setDefaultCommandName()` —
+that method does not exist. The only available delegation path from `App.run()` is via
+`spec.commandLine().getSubcommands().get("tui").execute()`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `atunko` (no args) launches the TUI, identical to `atunko tui`
+- `atunko --help` still prints root-level usage (unchanged — Picocli handles `--help` before `run()`)
+
+**Non-Goals:**
+- Propagating the TUI's exit code from `App.run()` (Picocli `Runnable.run()` is void; TUI exits with 0 on normal close)
+- Mouse support, sorting, or any other TUI feature
+
+## Decisions
+
+**Delegate via `getSubcommands().get("tui").execute()` instead of `setDefaultCommandName()`**
+Picocli 4.7.7 does not have `setDefaultCommandName`. Calling the subcommand's `execute()`
+from `App.run()` is the idiomatic fallback: Picocli has already wired the factory and all
+dependencies, so the subcommand executes with full context.
+
+**Test verifies registration, not execution**
+Launching TUI in a headless test environment is not possible (requires a real TTY). The
+test instead asserts that "tui" is registered in `cmd.getSubcommands()`, which is the
+necessary precondition for the delegation to succeed at runtime.
+
+## Risks / Trade-offs
+
+- **Exit code not propagated**: If TUI exits non-zero, `App.run()` still returns normally
+  and Picocli reports exit code 0. Acceptable — TUI closes cleanly on `q`/`Esc` with code 0.
+- **Headless test gap**: The delegation path itself is not exercised under test. The
+  registration check is a proxy. → Mitigation: manual smoke test (`./gradlew :atunko-cli:run`).

--- a/openspec/changes/tui-default-cli-7/proposal.md
+++ b/openspec/changes/tui-default-cli-7/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Running `atunko` without a subcommand printed the help/usage text — not useful as a default
+UX since the TUI is the primary interface. Issue #7 requires the bare `atunko` invocation
+to launch the TUI directly, the same as `atunko tui`.
+
+## What Changes
+
+- `App.run()` delegates to the registered "tui" subcommand via
+  `spec.commandLine().getSubcommands().get("tui").execute()` instead of printing usage
+- `@Requirements({"atunko:CLI_0001"})` added to `App.run()`
+- `AppTest.noArgsPrintsUsage` replaced by `tuiSubcommandIsRegistered` — verifies "tui" is
+  the registered subcommand the default path delegates to (TUI cannot be launched headlessly)
+
+## Capabilities
+
+### New Capabilities
+
+- `cli-default-tui`: Invoking `atunko` without arguments launches the interactive TUI
+
+## Impact
+
+- `atunko-cli`: `App` — one-line change to `run()`; new `CLI_0001` requirement added
+- `atunko-cli` tests: `AppTest` — one test replaced
+- `docs/reqstool/requirements.yml`: new `CLI_0001`
+- `docs/reqstool/software_verification_cases.yml`: new `SVC_CLI_0001`
+- No core, TUI, or web changes

--- a/openspec/changes/tui-default-cli-7/specs/cli-default-tui/spec.md
+++ b/openspec/changes/tui-default-cli-7/specs/cli-default-tui/spec.md
@@ -1,0 +1,7 @@
+## ADDED Requirements
+
+### Requirement: CLI_0001
+The system SHALL implement CLI_0001.
+
+#### Scenario: SVC_CLI_0001
+The system SHALL pass SVC_CLI_0001.

--- a/openspec/changes/tui-default-cli-7/tasks.md
+++ b/openspec/changes/tui-default-cli-7/tasks.md
@@ -1,0 +1,17 @@
+## 1. Requirements & SVCs
+
+- [x] 1.1 Add `CLI_0001` requirement to `docs/reqstool/requirements.yml`
+- [x] 1.2 Add `SVC_CLI_0001` to `docs/reqstool/software_verification_cases.yml`
+
+## 2. App — Default Delegation
+
+- [x] 2.1 Change `App.run()` to call `spec.commandLine().getSubcommands().get("tui").execute()`
+- [x] 2.2 Add `@Requirements({"atunko:CLI_0001"})` to `App.run()`
+
+## 3. Tests
+
+- [x] 3.1 Replace `noArgsPrintsUsage` with `tuiSubcommandIsRegistered` — asserts `cmd.getSubcommands()` contains key `"tui"`; annotate with `@SVCs({"atunko:SVC_CLI_0001"})`
+
+## 4. Quality
+
+- [x] 4.1 Run `./gradlew spotlessApply && ./gradlew :atunko-cli:test` — all tests pass, no violations

--- a/openspec/specs/cli-default-tui/spec.md
+++ b/openspec/specs/cli-default-tui/spec.md
@@ -1,0 +1,5 @@
+### Requirement: CLI_0001
+The system SHALL implement CLI_0001.
+
+#### Scenario: SVC_CLI_0001
+The system SHALL pass SVC_CLI_0001.


### PR DESCRIPTION
## Summary

- `App.run()` now delegates to the registered `tui` subcommand instead of printing usage, so running `atunko` without arguments launches the interactive TUI
- Adds `CLI_0001` requirement and `SVC_CLI_0001` verification case to reqstool
- Replaces `noArgsPrintsUsage` test with `tuiSubcommandIsRegistered` (TUI cannot be launched headlessly)

## Test plan

- [ ] `./gradlew :atunko-cli:test` passes
- [ ] `./gradlew :atunko-cli:run` launches the TUI (manual smoke test)
- [ ] `./gradlew :atunko-cli:run --args="--help"` still prints root usage