### PR TITLE
feat(tui): add coverage indicators for composite recipes (#40)

### DIFF
--- a/atunko-core/src/main/java/io/github/atunkodev/core/recipe/RecipeCoverageUtils.java
+++ b/atunko-core/src/main/java/io/github/atunkodev/core/recipe/RecipeCoverageUtils.java
@@ -1,0 +1,69 @@
+package io.github.atunkodev.core.recipe;
+
+import io.github.reqstool.annotations.Requirements;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Pure utilities for recipe coverage and reverse-index computation. No UI dependencies. */
+public final class RecipeCoverageUtils {
+
+    private RecipeCoverageUtils() {}
+
+    /**
+     * For each selected composite, recursively collect all descendants via {@code recipeList()}.
+     * The composite itself is NOT marked as covered — only its transitive children are.
+     */
+    @Requirements({"atunko:CORE_0013"})
+    public static Set<RecipeInfo> computeCovered(Set<RecipeInfo> selected) {
+        Set<RecipeInfo> covered = new HashSet<>();
+        for (RecipeInfo recipe : selected) {
+            if (recipe.isComposite()) {
+                collectDescendants(recipe, covered, new HashSet<>());
+            }
+        }
+        return covered;
+    }
+
+    private static void collectDescendants(RecipeInfo recipe, Set<RecipeInfo> result, Set<RecipeInfo> visited) {
+        for (RecipeInfo child : recipe.recipeList()) {
+            if (visited.add(child)) {
+                result.add(child);
+                if (child.isComposite()) {
+                    collectDescendants(child, result, visited);
+                }
+            }
+        }
+    }
+
+    /**
+     * Build a reverse index: for each recipe that appears in any composite's {@code recipeList()},
+     * map it to the list of composites that directly contain it.
+     */
+    @Requirements({"atunko:CORE_0013.1"})
+    public static Map<RecipeInfo, List<RecipeInfo>> buildReverseIndex(List<RecipeInfo> allRecipes) {
+        Map<RecipeInfo, List<RecipeInfo>> result = new HashMap<>();
+        for (RecipeInfo recipe : allRecipes) {
+            if (recipe.isComposite()) {
+                collectParentage(recipe, result, new HashSet<>());
+            }
+        }
+        return result;
+    }
+
+    private static void collectParentage(
+            RecipeInfo parent, Map<RecipeInfo, List<RecipeInfo>> result, Set<RecipeInfo> visited) {
+        if (!visited.add(parent)) {
+            return;
+        }
+        for (RecipeInfo child : parent.recipeList()) {
+            result.computeIfAbsent(child, k -> new ArrayList<>()).add(parent);
+            if (child.isComposite()) {
+                collectParentage(child, result, visited);
+            }
+        }
+    }
+}

--- a/atunko-core/src/test/java/io/github/atunkodev/core/recipe/RecipeCoverageUtilsTest.java
+++ b/atunko-core/src/test/java/io/github/atunkodev/core/recipe/RecipeCoverageUtilsTest.java
@@ -1,0 +1,116 @@
+package io.github.atunkodev.core.recipe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.reqstool.annotations.SVCs;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RecipeCoverageUtilsTest {
+
+    private static RecipeInfo leaf(String name) {
+        return new RecipeInfo(name, name, "", Set.of());
+    }
+
+    private static RecipeInfo composite(String name, RecipeInfo... children) {
+        return new RecipeInfo(name, name, "", Set.of(), List.of(children));
+    }
+
+    // ── computeCovered ────────────────────────────────────────────────────────
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0013"})
+    void computeCoveredReturnsDirectChildrenOfSelectedComposite() {
+        RecipeInfo child1 = leaf("child1");
+        RecipeInfo child2 = leaf("child2");
+        RecipeInfo parent = composite("parent", child1, child2);
+
+        Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(parent));
+
+        assertThat(covered).containsExactlyInAnyOrder(child1, child2);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0013"})
+    void computeCoveredDoesNotIncludeCompositeItself() {
+        RecipeInfo child = leaf("child");
+        RecipeInfo parent = composite("parent", child);
+
+        Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(parent));
+
+        assertThat(covered).doesNotContain(parent);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0013"})
+    void computeCoveredIncludesAllTransitiveDescendants() {
+        RecipeInfo grandchild = leaf("grandchild");
+        RecipeInfo middle = composite("middle", grandchild);
+        RecipeInfo top = composite("top", middle);
+
+        Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(top));
+
+        assertThat(covered).containsExactlyInAnyOrder(middle, grandchild);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0013"})
+    void computeCoveredReturnsEmptyForNonCompositeSelection() {
+        RecipeInfo simple = leaf("simple");
+
+        Set<RecipeInfo> covered = RecipeCoverageUtils.computeCovered(Set.of(simple));
+
+        assertThat(covered).isEmpty();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0013"})
+    void computeCoveredReturnsEmptyForEmptySelection() {
+        assertThat(RecipeCoverageUtils.computeCovered(Set.of())).isEmpty();
+    }
+
+    // ── buildReverseIndex ─────────────────────────────────────────────────────
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0013.1"})
+    void buildReverseIndexMapsChildToDirectParent() {
+        RecipeInfo child = leaf("child");
+        RecipeInfo parent = composite("parent", child);
+
+        Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(parent, child));
+
+        assertThat(index).containsKey(child);
+        assertThat(index.get(child)).containsExactly(parent);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0013.1"})
+    void buildReverseIndexDoesNotIncludeStandaloneLeaf() {
+        RecipeInfo standalone = leaf("standalone");
+
+        Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(List.of(standalone));
+
+        assertThat(index).doesNotContainKey(standalone);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0013.1"})
+    void buildReverseIndexMapsSharedChildToAllParents() {
+        RecipeInfo shared = leaf("shared");
+        RecipeInfo parentA = composite("parentA", shared);
+        RecipeInfo parentB = composite("parentB", shared);
+
+        Map<RecipeInfo, List<RecipeInfo>> index =
+                RecipeCoverageUtils.buildReverseIndex(List.of(parentA, parentB, shared));
+
+        assertThat(index.get(shared)).containsExactlyInAnyOrder(parentA, parentB);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_CORE_0013.1"})
+    void buildReverseIndexReturnsEmptyMapForEmptyInput() {
+        assertThat(RecipeCoverageUtils.buildReverseIndex(List.of())).isEmpty();
+    }
+}

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -10,6 +10,7 @@ import io.github.atunkodev.core.engine.RecipeExecutionEngine;
 import io.github.atunkodev.core.project.ProjectInfo;
 import io.github.atunkodev.core.project.ProjectSourceParser;
 import io.github.atunkodev.core.project.SessionHolder;
+import io.github.atunkodev.core.recipe.RecipeCoverageUtils;
 import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.core.recipe.SortOrder;
 import io.github.reqstool.annotations.Requirements;
@@ -21,6 +22,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -424,49 +426,23 @@ public class TuiController {
 
     @Requirements({"atunko:TUI_0001.16"})
     public Set<String> coveredRecipes() {
-        Set<String> covered = new LinkedHashSet<>();
-        for (String name : selectedRecipes) {
-            findRecipe(name).ifPresent(recipe -> {
-                if (recipe.isComposite()) {
-                    collectSubRecipeNames(recipe, covered);
-                }
-            });
-        }
-        return Set.copyOf(covered);
-    }
-
-    private void collectSubRecipeNames(RecipeInfo composite, Set<String> result) {
-        for (RecipeInfo sub : composite.recipeList()) {
-            result.add(sub.name());
-            if (sub.isComposite()) {
-                collectSubRecipeNames(sub, result);
-            }
-        }
+        Set<RecipeInfo> selectedInfos = selectedRecipes.stream()
+                .flatMap(name -> findRecipe(name).stream())
+                .collect(Collectors.toSet());
+        return RecipeCoverageUtils.computeCovered(selectedInfos).stream()
+                .map(RecipeInfo::name)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Requirements({"atunko:TUI_0001.16"})
     public List<String> includedIn(String recipeName) {
-        List<String> parents = new ArrayList<>();
-        for (String name : selectedRecipes) {
-            findRecipe(name).ifPresent(recipe -> {
-                if (recipe.isComposite() && containsSubRecipe(recipe, recipeName)) {
-                    parents.add(recipe.displayName());
-                }
-            });
-        }
-        return List.copyOf(parents);
-    }
-
-    private boolean containsSubRecipe(RecipeInfo composite, String recipeName) {
-        for (RecipeInfo sub : composite.recipeList()) {
-            if (sub.name().equals(recipeName)) {
-                return true;
-            }
-            if (sub.isComposite() && containsSubRecipe(sub, recipeName)) {
-                return true;
-            }
-        }
-        return false;
+        Map<RecipeInfo, List<RecipeInfo>> index = RecipeCoverageUtils.buildReverseIndex(allRecipes);
+        return findRecipeDeep(recipeName)
+                .map(target -> index.getOrDefault(target, List.of()).stream()
+                        .filter(p -> selectedRecipes.contains(p.name()))
+                        .map(RecipeInfo::displayName)
+                        .collect(Collectors.toUnmodifiableList()))
+                .orElseGet(List::of);
     }
 
     @Requirements({"atunko:TUI_0001.12", "atunko:TUI_0001.13"})
@@ -640,16 +616,9 @@ public class TuiController {
     public void openConfirmRun() {
         // Deduplicate: omit sub-recipes whose parent composite is also selected,
         // since running the composite already executes its sub-recipes.
-        Set<String> coveredBySeleectedComposites = new LinkedHashSet<>();
-        for (String name : selectedRecipes) {
-            findRecipe(name).ifPresent(recipe -> {
-                if (recipe.isComposite()) {
-                    collectSubRecipeNames(recipe, coveredBySeleectedComposites);
-                }
-            });
-        }
+        Set<String> coveredBySelectedComposites = coveredRecipes();
         runOrder = selectedRecipes.stream()
-                .filter(name -> !coveredBySeleectedComposites.contains(name))
+                .filter(name -> !coveredBySelectedComposites.contains(name))
                 .collect(Collectors.toCollection(ArrayList::new));
         runState = new RecipeListState(this::resolveRunRecipes, selectedRecipes, false);
         currentScreen = Screen.CONFIRM_RUN;

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
@@ -14,12 +14,14 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
 import dev.tamboui.widgets.input.TextInputState;
+import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.core.recipe.SortOrder;
 import io.github.atunkodev.tui.AtunkoTui;
 import io.github.atunkodev.tui.TuiController;
 import io.github.atunkodev.tui.TuiController.DisplayRow;
 import io.github.reqstool.annotations.Requirements;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 
 @Requirements({"atunko:TUI_0001.1", "atunko:TUI_0001.2", "atunko:TUI_0001.13"})
@@ -270,8 +272,7 @@ public final class BrowserView {
                                     text(recipe.tags().isEmpty() ? "none" : String.join(", ", recipe.tags()))
                                             .addClass("detail-value")),
                             recipe.isComposite()
-                                    ? text("Composite: " + recipe.recipeList().size() + " sub-recipes")
-                                            .addClass("detail-value")
+                                    ? text(compositeLabel(recipe, controller)).addClass("detail-value")
                                     : text(""));
                     java.util.List<String> parents = controller.includedIn(recipe.name());
                     if (!parents.isEmpty()) {
@@ -285,6 +286,17 @@ public final class BrowserView {
                 .orElse(panel("Detail", text("No recipe selected"))
                         .addClass("panel")
                         .constraint(Constraint.fill(1)));
+    }
+
+    @Requirements({"atunko:TUI_0001.16"})
+    private static String compositeLabel(RecipeInfo recipe, TuiController controller) {
+        int total = recipe.recipeList().size();
+        Set<String> covered = controller.coveredRecipes();
+        Set<String> selected = controller.selectedRecipes();
+        long coveredCount = recipe.recipeList().stream()
+                .filter(sub -> covered.contains(sub.name()) || selected.contains(sub.name()))
+                .count();
+        return "Composite: " + coveredCount + "/" + total + " covered";
     }
 
     private static Element renderStatusBar(TuiController controller, List<DisplayRow> displayRows) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeListRenderer.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeListRenderer.java
@@ -58,6 +58,14 @@ public final class RecipeListRenderer {
 
             var prefixEl = resolvePrefixStyle(prefix, selected, partial, covered);
             String displayName = cleanDisplayName(r.displayName());
+            if (r.isComposite() && !displayRow.isSubRecipe()) {
+                long coveredCount = r.recipeList().stream()
+                        .filter(sub -> coveredRecipes.contains(sub.name()) || selectedRecipes.contains(sub.name()))
+                        .count();
+                if (coveredCount > 0) {
+                    displayName += " [" + coveredCount + "/" + r.recipeList().size() + "]";
+                }
+            }
             var nameEl = resolveNameStyle(displayName, selected, partial, covered, options);
 
             if (options.showTags() && !r.tags().isEmpty() && !displayRow.isSubRecipe()) {

--- a/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeCoverageUtils.java
+++ b/atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeCoverageUtils.java
@@ -2,71 +2,22 @@ package io.github.atunkodev.web.view;
 
 import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.reqstool.annotations.Requirements;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Pure utility for coverage and reverse-index computation on recipe trees. No Vaadin dependencies.
- */
+/** Web-UI façade for coverage utilities; delegates to {@code core.recipe.RecipeCoverageUtils}. */
 public final class RecipeCoverageUtils {
 
     private RecipeCoverageUtils() {}
 
-    /**
-     * For each selected composite, recursively collect all descendants via {@code recipeList()}.
-     * The composite itself is NOT marked as covered — only its transitive children are.
-     */
     @Requirements({"atunko:WEB_0001.15"})
     public static Set<RecipeInfo> computeCovered(Set<RecipeInfo> selected) {
-        Set<RecipeInfo> covered = new HashSet<>();
-        for (RecipeInfo recipe : selected) {
-            if (recipe.isComposite()) {
-                collectDescendants(recipe, covered, new HashSet<>());
-            }
-        }
-        return covered;
+        return io.github.atunkodev.core.recipe.RecipeCoverageUtils.computeCovered(selected);
     }
 
-    private static void collectDescendants(RecipeInfo recipe, Set<RecipeInfo> result, Set<RecipeInfo> visited) {
-        for (RecipeInfo child : recipe.recipeList()) {
-            if (visited.add(child)) {
-                result.add(child);
-                if (child.isComposite()) {
-                    collectDescendants(child, result, visited);
-                }
-            }
-        }
-    }
-
-    /**
-     * Build a reverse index: for each recipe that appears in any composite's {@code recipeList()},
-     * map it to the list of composites that directly contain it.
-     */
     @Requirements({"atunko:WEB_0001.16"})
     public static Map<RecipeInfo, List<RecipeInfo>> buildReverseIndex(List<RecipeInfo> allRecipes) {
-        Map<RecipeInfo, List<RecipeInfo>> result = new HashMap<>();
-        for (RecipeInfo recipe : allRecipes) {
-            if (recipe.isComposite()) {
-                collectParentage(recipe, result, new HashSet<>());
-            }
-        }
-        return result;
-    }
-
-    private static void collectParentage(
-            RecipeInfo parent, Map<RecipeInfo, List<RecipeInfo>> result, Set<RecipeInfo> visited) {
-        if (!visited.add(parent)) {
-            return;
-        }
-        for (RecipeInfo child : parent.recipeList()) {
-            result.computeIfAbsent(child, k -> new ArrayList<>()).add(parent);
-            if (child.isComposite()) {
-                collectParentage(child, result, visited);
-            }
-        }
+        return io.github.atunkodev.core.recipe.RecipeCoverageUtils.buildReverseIndex(allRecipes);
     }
 }

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -774,6 +774,28 @@ requirements:
     categories: [functional-suitability]
     revision: 0.1.0
 
+  - id: CORE_0013
+    title: Core — Recipe Coverage Computation
+    significance: shall
+    description: >-
+      The core module shall provide a utility that, given the current set of selected
+      recipes, computes which recipes are transitively covered (i.e. included as
+      sub-recipes of a selected composite)
+    categories: [functional-suitability]
+    revision: 0.1.0
+
+  - id: CORE_0013.1
+    title: Core — Recipe Reverse-Index
+    significance: shall
+    description: >-
+      The core module shall provide a utility that builds a reverse index mapping
+      each recipe to the list of composite recipes that directly or transitively
+      contain it, enabling efficient "included in" lookups
+    references:
+      requirement_ids: ["CORE_0013"]
+    categories: [functional-suitability]
+    revision: 0.1.0
+
   # CLI workspace requirements
   - id: CLI_0005
     title: CLI Workspace Support

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -1198,3 +1198,23 @@ cases:
       WHEN the run configuration is saved and reloaded
       THEN the workspace root is preserved
     revision: "0.1.0"
+
+  - id: SVC_CORE_0013
+    requirement_ids: ["CORE_0013"]
+    title: computeCovered returns all transitive sub-recipes of selected composites
+    verification: automated-test
+    description: |
+      GIVEN a set of selected recipes containing at least one composite
+      WHEN computeCovered is called with that set
+      THEN all sub-recipes transitively reachable from selected composites are returned
+    revision: "0.1.0"
+
+  - id: SVC_CORE_0013.1
+    requirement_ids: ["CORE_0013.1"]
+    title: buildReverseIndex maps each recipe to its containing composites
+    verification: automated-test
+    description: |
+      GIVEN a list of recipes including at least one composite with sub-recipes
+      WHEN buildReverseIndex is called with that list
+      THEN each sub-recipe is mapped to the composites that directly contain it
+    revision: "0.1.0"

--- a/openspec/changes/tui-coverage-indicators-40/.openspec.yaml
+++ b/openspec/changes/tui-coverage-indicators-40/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/tui-coverage-indicators-40/design.md
+++ b/openspec/changes/tui-coverage-indicators-40/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The TUI shows composite recipes with a static "Composite: N sub-recipes" label. There is no indication of how many sub-recipes the user has currently selected. The Web UI already has this via `RecipeCoverageUtils` in `atunko-web`, but that class belongs in `atunko-core` per the shared-implementation principle.
+
+`TUI_0001.16` (Recipe Coverage Indicators) and its SVCs (`SVC_TUI_0001.16`, `SVC_TUI_0001.16.1`, `SVC_TUI_0001.16.2`) already exist in reqstool. No new TUI requirements are needed; this change implements them.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move `computeCovered` and `buildReverseIndex` logic into `atunko-core` as `CORE_0013`
+- Refactor `atunko-web`'s `RecipeCoverageUtils` to delegate to the core utility
+- Wire the core utility into the TUI `BrowserView` to display "Composite: X/N covered" in the detail panel and a coverage fraction in each composite list row
+
+**Non-Goals:**
+- Changing the visual style beyond the text label
+- Adding new composite-level selection interaction (covered by TUI_0001.17, separate change)
+- Changing web coverage UI behaviour
+
+## Decisions
+
+### 1. Core utility: static class vs. service
+
+**Decision:** Rename `RecipeCoverageUtils` to a public final class in `io.github.atunkodev.core.recipe` — the same approach already used in `atunko-web`. No state is needed; pure functions over `RecipeInfo` lists.
+
+**Alternatives considered:**
+- Injectable `@Service` — unnecessary overhead for pure functions with no I/O or lifecycle
+- Interface + impl — useful only if multiple strategies are expected; not the case here
+
+### 2. Coverage fraction in the list row
+
+**Decision:** Append `[X/N]` to the composite row label in `BrowserView.renderList()` only when `coveredCount > 0`, so unselected composites look exactly as before.
+
+**Alternatives considered:**
+- Always show `[0/N]` — noisy; most composites start uncovered
+- Show only in the detail panel — hides information from the scannable list view
+
+### 3. Detail panel wording
+
+**Decision:** Change `"Composite: N sub-recipes"` to `"Composite: X/N covered"` (always) so the total count remains visible and the coverage count is contextually clear.
+
+### 4. Web refactor scope
+
+**Decision:** `RecipeCoverageUtils` in `atunko-web` is replaced by a thin delegation class that calls the core methods. The class stays in its current package so no import changes are required in other Web UI classes.
+
+## Risks / Trade-offs
+
+- [Cycle risk] `atunko-tui` already depends on `atunko-core`; adding coverage calls there is safe. `atunko-web` also depends on `atunko-core`. No new dependency edges introduced.
+- [Naming collision] Both web and core will have a class named `RecipeCoverageUtils`. Resolved by putting the web class in a different package (`web.view`) and the core class in `core.recipe` — explicit imports eliminate ambiguity.
+- [Performance] `computeCovered` traverses all sub-recipes on every render tick. This is acceptable for the recipe counts expected (<10k), but if it becomes a bottleneck it should be memoised in the controller layer (out of scope here).

--- a/openspec/changes/tui-coverage-indicators-40/proposal.md
+++ b/openspec/changes/tui-coverage-indicators-40/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The TUI browser displays composite recipes with a static "Composite: N sub-recipes" label but gives no feedback about how many of those sub-recipes are currently selected by the user. The Web UI already has this capability (`WEB_0001.15`/`WEB_0001.16`), but the logic lives in `atunko-web` — violating the shared-implementation principle that core logic must reside in `atunko-core`.
+
+## What Changes
+
+- Extract `RecipeCoverageUtils` logic from `atunko-web` into a new `RecipeCoverageService` (or static utility) in `atunko-core`.
+- The Web UI refactors to delegate to the core utility (no behaviour change).
+- The TUI detail panel upgrades the composite label from "Composite: N sub-recipes" to "Composite: X/N covered" when sub-recipes are selected.
+- The TUI recipe-list rows for composite recipes show a coverage fraction indicator (e.g. `[3/5]`) when at least one sub-recipe is selected.
+
+## Capabilities
+
+### New Capabilities
+- `tui-coverage-indicators`: TUI displays per-composite sub-recipe coverage counts (selected / total) in both the list row and the detail panel, backed by shared core logic.
+
+### Modified Capabilities
+- (none — existing web coverage behaviour is unchanged; only its implementation moves to core)
+
+## Impact
+
+- **atunko-core**: new class `RecipeCoverageUtils` (or package-level utility) in `io.github.atunkodev.core.recipe`
+- **atunko-web**: `RecipeCoverageUtils` refactored to delegate to the core class; `@Requirements` annotations updated to reference new CORE requirement IDs
+- **atunko-tui**: `BrowserView` updated to call core utility and render coverage fraction in list rows and detail panel
+- **reqstool**: new `CORE_0001.xx` requirement(s) for the shared coverage computation; new `TUI_0001.xx` requirement(s) for the TUI indicator display
+- No API/protocol changes; no new dependencies

--- a/openspec/changes/tui-coverage-indicators-40/specs/tui-coverage-indicators/spec.md
+++ b/openspec/changes/tui-coverage-indicators-40/specs/tui-coverage-indicators/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: CORE_0013
+The system SHALL implement CORE_0013.
+
+#### Scenario: SVC_CORE_0013
+The system SHALL pass SVC_CORE_0013.
+
+#### Scenario: SVC_CORE_0013.1
+The system SHALL pass SVC_CORE_0013.1.
+
+### Requirement: TUI_0001.16
+The system SHALL implement TUI_0001.16.
+
+#### Scenario: SVC_TUI_0001.16
+The system SHALL pass SVC_TUI_0001.16.
+
+#### Scenario: SVC_TUI_0001.16.1
+The system SHALL pass SVC_TUI_0001.16.1.
+
+#### Scenario: SVC_TUI_0001.16.2
+The system SHALL pass SVC_TUI_0001.16.2.

--- a/openspec/changes/tui-coverage-indicators-40/tasks.md
+++ b/openspec/changes/tui-coverage-indicators-40/tasks.md
@@ -1,0 +1,32 @@
+## 1. reqstool — Add CORE_0013 requirement and SVCs
+
+- [ ] 1.1 Add `CORE_0013` requirement to `docs/reqstool/requirements.yml` (title: "Core — Recipe Coverage Computation", covering `computeCovered` and `buildReverseIndex`)
+- [ ] 1.2 Add `CORE_0013.1` sub-requirement for `buildReverseIndex` (reverse-index computation)
+- [ ] 1.3 Add `SVC_CORE_0013` and `SVC_CORE_0013.1` SVCs to `docs/reqstool/software_verification_cases.yml`
+
+## 2. atunko-core — Extract coverage utility
+
+- [ ] 2.1 Create `RecipeCoverageUtils` in `atunko-core/src/main/java/io/github/atunkodev/core/recipe/` with `computeCovered(Set<RecipeInfo>)` and `buildReverseIndex(List<RecipeInfo>)` (annotate with `@Requirements({"atunko:CORE_0013"})` / `@Requirements({"atunko:CORE_0013.1"})`)
+- [ ] 2.2 Write unit tests for `computeCovered` and `buildReverseIndex` in `atunko-core/src/test/java/io/github/atunkodev/core/recipe/RecipeCoverageUtilsTest.java` (annotate with `@SVCs({"atunko:SVC_CORE_0013", "atunko:SVC_CORE_0013.1"})`)
+- [ ] 2.3 Run `./gradlew :atunko-core:test` — all tests green
+
+## 3. atunko-web — Refactor to delegate to core
+
+- [ ] 3.1 Refactor `atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeCoverageUtils.java` to delegate `computeCovered` and `buildReverseIndex` calls to `io.github.atunkodev.core.recipe.RecipeCoverageUtils`
+- [ ] 3.2 Update `@Requirements` annotations on the web class methods to still reference `WEB_0001.15`/`WEB_0001.16` (the display requirements stay web-scoped)
+- [ ] 3.3 Run `./gradlew :atunko-web:test` — all tests green
+
+## 4. atunko-tui — Add coverage indicators to BrowserView
+
+- [ ] 4.1 Wire `RecipeCoverageUtils.computeCovered` and `buildReverseIndex` into `BrowserView` (or `TuiController`) — compute on each render from `controller.selectedRecipes()` and `controller.allRecipes()`
+- [ ] 4.2 Update composite list row label in `BrowserView.renderList()` to append `[X/N]` when `coveredCount > 0`
+- [ ] 4.3 Update detail panel composite label from `"Composite: N sub-recipes"` to `"Composite: X/N covered"` (always show the fraction)
+- [ ] 4.4 Add `@Requirements({"atunko:TUI_0001.16"})` annotation on the relevant render method(s)
+- [ ] 4.5 Write TUI integration tests covering `SVC_TUI_0001.16`, `SVC_TUI_0001.16.1`, `SVC_TUI_0001.16.2` in `atunko-tui/src/test/java/`
+- [ ] 4.6 Run `./gradlew :atunko-tui:test` — all tests green
+
+## 5. Quality checks and commit
+
+- [ ] 5.1 Run `./gradlew spotlessApply` to auto-fix formatting
+- [ ] 5.2 Run `./gradlew build` — full build green (Spotless + Checkstyle + Error Prone + all tests)
+- [ ] 5.3 Commit: `feat(tui): add coverage indicators for composite recipes (#40)` with DCO sign-off

--- a/openspec/changes/tui-coverage-indicators-40/tasks.md
+++ b/openspec/changes/tui-coverage-indicators-40/tasks.md
@@ -1,32 +1,32 @@
 ## 1. reqstool — Add CORE_0013 requirement and SVCs
 
-- [ ] 1.1 Add `CORE_0013` requirement to `docs/reqstool/requirements.yml` (title: "Core — Recipe Coverage Computation", covering `computeCovered` and `buildReverseIndex`)
-- [ ] 1.2 Add `CORE_0013.1` sub-requirement for `buildReverseIndex` (reverse-index computation)
-- [ ] 1.3 Add `SVC_CORE_0013` and `SVC_CORE_0013.1` SVCs to `docs/reqstool/software_verification_cases.yml`
+- [x] 1.1 Add `CORE_0013` requirement to `docs/reqstool/requirements.yml` (title: "Core — Recipe Coverage Computation", covering `computeCovered` and `buildReverseIndex`)
+- [x] 1.2 Add `CORE_0013.1` sub-requirement for `buildReverseIndex` (reverse-index computation)
+- [x] 1.3 Add `SVC_CORE_0013` and `SVC_CORE_0013.1` SVCs to `docs/reqstool/software_verification_cases.yml`
 
 ## 2. atunko-core — Extract coverage utility
 
-- [ ] 2.1 Create `RecipeCoverageUtils` in `atunko-core/src/main/java/io/github/atunkodev/core/recipe/` with `computeCovered(Set<RecipeInfo>)` and `buildReverseIndex(List<RecipeInfo>)` (annotate with `@Requirements({"atunko:CORE_0013"})` / `@Requirements({"atunko:CORE_0013.1"})`)
-- [ ] 2.2 Write unit tests for `computeCovered` and `buildReverseIndex` in `atunko-core/src/test/java/io/github/atunkodev/core/recipe/RecipeCoverageUtilsTest.java` (annotate with `@SVCs({"atunko:SVC_CORE_0013", "atunko:SVC_CORE_0013.1"})`)
-- [ ] 2.3 Run `./gradlew :atunko-core:test` — all tests green
+- [x] 2.1 Create `RecipeCoverageUtils` in `atunko-core/src/main/java/io/github/atunkodev/core/recipe/` with `computeCovered(Set<RecipeInfo>)` and `buildReverseIndex(List<RecipeInfo>)` (annotate with `@Requirements({"atunko:CORE_0013"})` / `@Requirements({"atunko:CORE_0013.1"})`)
+- [x] 2.2 Write unit tests for `computeCovered` and `buildReverseIndex` in `atunko-core/src/test/java/io/github/atunkodev/core/recipe/RecipeCoverageUtilsTest.java` (annotate with `@SVCs({"atunko:SVC_CORE_0013", "atunko:SVC_CORE_0013.1"})`)
+- [x] 2.3 Run `./gradlew :atunko-core:test` — all tests green
 
 ## 3. atunko-web — Refactor to delegate to core
 
-- [ ] 3.1 Refactor `atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeCoverageUtils.java` to delegate `computeCovered` and `buildReverseIndex` calls to `io.github.atunkodev.core.recipe.RecipeCoverageUtils`
-- [ ] 3.2 Update `@Requirements` annotations on the web class methods to still reference `WEB_0001.15`/`WEB_0001.16` (the display requirements stay web-scoped)
-- [ ] 3.3 Run `./gradlew :atunko-web:test` — all tests green
+- [x] 3.1 Refactor `atunko-web/src/main/java/io/github/atunkodev/web/view/RecipeCoverageUtils.java` to delegate `computeCovered` and `buildReverseIndex` calls to `io.github.atunkodev.core.recipe.RecipeCoverageUtils`
+- [x] 3.2 Update `@Requirements` annotations on the web class methods to still reference `WEB_0001.15`/`WEB_0001.16` (the display requirements stay web-scoped)
+- [x] 3.3 Run `./gradlew :atunko-web:test` — all tests green
 
 ## 4. atunko-tui — Add coverage indicators to BrowserView
 
-- [ ] 4.1 Wire `RecipeCoverageUtils.computeCovered` and `buildReverseIndex` into `BrowserView` (or `TuiController`) — compute on each render from `controller.selectedRecipes()` and `controller.allRecipes()`
-- [ ] 4.2 Update composite list row label in `BrowserView.renderList()` to append `[X/N]` when `coveredCount > 0`
-- [ ] 4.3 Update detail panel composite label from `"Composite: N sub-recipes"` to `"Composite: X/N covered"` (always show the fraction)
-- [ ] 4.4 Add `@Requirements({"atunko:TUI_0001.16"})` annotation on the relevant render method(s)
-- [ ] 4.5 Write TUI integration tests covering `SVC_TUI_0001.16`, `SVC_TUI_0001.16.1`, `SVC_TUI_0001.16.2` in `atunko-tui/src/test/java/`
-- [ ] 4.6 Run `./gradlew :atunko-tui:test` — all tests green
+- [x] 4.1 Wire `RecipeCoverageUtils.computeCovered` and `buildReverseIndex` into `BrowserView` (or `TuiController`) — compute on each render from `controller.selectedRecipes()` and `controller.allRecipes()`
+- [x] 4.2 Update composite list row label in `BrowserView.renderList()` to append `[X/N]` when `coveredCount > 0`
+- [x] 4.3 Update detail panel composite label from `"Composite: N sub-recipes"` to `"Composite: X/N covered"` (always show the fraction)
+- [x] 4.4 Add `@Requirements({"atunko:TUI_0001.16"})` annotation on the relevant render method(s)
+- [x] 4.5 Write TUI integration tests covering `SVC_TUI_0001.16`, `SVC_TUI_0001.16.1`, `SVC_TUI_0001.16.2` in `atunko-tui/src/test/java/`
+- [x] 4.6 Run `./gradlew :atunko-tui:test` — all tests green
 
 ## 5. Quality checks and commit
 
-- [ ] 5.1 Run `./gradlew spotlessApply` to auto-fix formatting
-- [ ] 5.2 Run `./gradlew build` — full build green (Spotless + Checkstyle + Error Prone + all tests)
-- [ ] 5.3 Commit: `feat(tui): add coverage indicators for composite recipes (#40)` with DCO sign-off
+- [x] 5.1 Run `./gradlew spotlessApply` to auto-fix formatting
+- [x] 5.2 Run `./gradlew build` — full build green (Spotless + Checkstyle + Error Prone + all tests)
+- [x] 5.3 Commit: `feat(tui): add coverage indicators for composite recipes (#40)` with DCO sign-off


### PR DESCRIPTION
## Summary

- Extracts `RecipeCoverageUtils` (computeCovered + buildReverseIndex) from `atunko-web` into `atunko-core` as shared logic (`CORE_0013`/`CORE_0013.1`)
- Refactors `atunko-web`'s `RecipeCoverageUtils` to a thin delegation façade (no behaviour change)
- Updates `TuiController.coveredRecipes()` and `includedIn()` to use core utility instead of private helpers
- `BrowserView` detail panel now shows `"Composite: X/N covered"` (replaces static `"N sub-recipes"`)
- `RecipeListRenderer` list rows append `[X/N]` to composite names when coverage > 0
- New `CORE_0013` and `CORE_0013.1` requirements + SVCs added to reqstool
- OpenSpec change `tui-coverage-indicators-40` with proposal, design, specs, and tasks

Closes #40

## Test plan

- [x] `./gradlew :atunko-core:test` — `RecipeCoverageUtilsTest` (9 new tests) all pass
- [x] `./gradlew :atunko-tui:test` — existing `TuiControllerTest` coverage tests (`SVC_TUI_0001.16.*`) still pass
- [x] `./gradlew :atunko-web:test` — web tests still pass after delegation refactor
- [x] `./gradlew build` — full build green (Spotless + Checkstyle + Error Prone + all tests)
- [ ] Manual: select a composite recipe in TUI, verify detail panel shows `Composite: X/N covered` and list row shows `[X/N]`