### PR TITLE
feat(tui): add workspace (multi-project) support (#12)

### DIFF
--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
@@ -48,6 +48,7 @@ public class AtunkoTui extends ToolkitApp {
             case DETAIL -> DetailView.render(controller);
             case TAG_BROWSER -> TagBrowserView.render(controller);
             case EXECUTION_RESULTS -> ExecutionResultsView.render(controller);
+            case WORKSPACE_RESULTS -> ExecutionResultsView.render(controller);
             case FILE_DIFF -> FileDiffView.render(controller);
             case CONFIRM_RUN -> ConfirmRunView.render(controller);
             case LOAD_CONFIG -> LoadConfigView.render(controller);

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/Screen.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/Screen.java
@@ -6,6 +6,7 @@ public enum Screen {
     TAG_BROWSER,
     CONFIRM_RUN,
     EXECUTION_RESULTS,
+    WORKSPACE_RESULTS,
     LOAD_CONFIG,
     FILE_DIFF
 }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiCommand.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiCommand.java
@@ -3,9 +3,12 @@ package io.github.atunkodev.tui;
 import io.github.atunkodev.core.config.RunConfigService;
 import io.github.atunkodev.core.engine.ChangeApplier;
 import io.github.atunkodev.core.engine.RecipeExecutionEngine;
+import io.github.atunkodev.core.engine.WorkspaceExecutionEngine;
 import io.github.atunkodev.core.project.ProjectScannerFactory;
 import io.github.atunkodev.core.project.ProjectSourceParser;
 import io.github.atunkodev.core.project.SessionHolder;
+import io.github.atunkodev.core.project.Workspace;
+import io.github.atunkodev.core.project.WorkspaceScanner;
 import io.github.atunkodev.core.recipe.RecipeDiscoveryService;
 import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.reqstool.annotations.Requirements;
@@ -23,8 +26,13 @@ public class TuiCommand implements Runnable {
     private final ProjectSourceParser sourceParser;
     private final ChangeApplier changeApplier;
 
-    @Option(names = "--project-dir", description = "Project directory", defaultValue = ".")
+    @Option(names = "--project-dir", description = "Project directory (mutually exclusive with --workspace)")
     private Path projectDir;
+
+    @Option(
+            names = "--workspace",
+            description = "Workspace root — scans for all projects underneath (mutually exclusive with --project-dir)")
+    private Path workspaceDir;
 
     @Option(names = "--log-file", description = "Log file for TUI debug output")
     private Path logFile;
@@ -49,12 +57,21 @@ public class TuiCommand implements Runnable {
     }
 
     @Override
-    @Requirements({"atunko:TUI_0001"})
+    @Requirements({"atunko:TUI_0001", "atunko:TUI_0002", "atunko:TUI_0002.1"})
     public void run() {
-        SessionHolder.init(projectDir, ProjectScannerFactory.detect(projectDir).scan(projectDir));
         List<RecipeInfo> recipes = discoveryService.discoverAll();
-        TuiController controller =
-                new TuiController(recipes, runConfigService, engine, sourceParser, changeApplier, projectDir);
+        TuiController controller;
+        if (workspaceDir != null) {
+            Workspace workspace = WorkspaceScanner.scan(workspaceDir);
+            SessionHolder.initWorkspace(workspace.root(), workspace.projects());
+            WorkspaceExecutionEngine workspaceEngine = new WorkspaceExecutionEngine(engine, sourceParser);
+            controller = new TuiController(
+                    recipes, runConfigService, engine, sourceParser, changeApplier, workspaceEngine, workspaceDir);
+        } else {
+            Path dir = projectDir != null ? projectDir : Path.of(".");
+            SessionHolder.init(dir, ProjectScannerFactory.detect(dir).scan(dir));
+            controller = new TuiController(recipes, runConfigService, engine, sourceParser, changeApplier, dir);
+        }
         ThemeConfig themeConfig = ThemeConfig.resolve(theme, cssFile);
         AtunkoTui tui = new AtunkoTui(controller, logFile, themeConfig);
         try {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -7,9 +7,13 @@ import io.github.atunkodev.core.engine.ChangeApplier;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
 import io.github.atunkodev.core.engine.RecipeExecutionEngine;
+import io.github.atunkodev.core.engine.WorkspaceExecutionEngine;
+import io.github.atunkodev.core.engine.WorkspaceExecutionResult;
+import io.github.atunkodev.core.project.ProjectEntry;
 import io.github.atunkodev.core.project.ProjectInfo;
 import io.github.atunkodev.core.project.ProjectSourceParser;
 import io.github.atunkodev.core.project.SessionHolder;
+import io.github.atunkodev.core.project.Workspace;
 import io.github.atunkodev.core.recipe.RecipeCoverageUtils;
 import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.core.recipe.SortOrder;
@@ -297,7 +301,9 @@ public class TuiController {
     private final RecipeExecutionEngine engine;
     private final ProjectSourceParser sourceParser;
     private final ChangeApplier changeApplier;
+    private final WorkspaceExecutionEngine workspaceEngine;
     private final Path projectDir;
+    private final List<ProjectEntry> workspaceProjects;
     private Screen currentScreen = Screen.BROWSER;
     private String searchQuery = "";
     private SortOrder sortOrder = SortOrder.NAME;
@@ -306,6 +312,7 @@ public class TuiController {
     private boolean searchMode;
     private boolean showHelp;
     private ExecutionResult executionResult;
+    private WorkspaceExecutionResult workspaceResult;
     private boolean lastRunWasDryRun;
     private int selectedFileIndex = 0;
 
@@ -330,11 +337,44 @@ public class TuiController {
             ProjectSourceParser sourceParser,
             ChangeApplier changeApplier,
             Path projectDir) {
+        this(allRecipes, runConfigService, engine, sourceParser, changeApplier, null, null, projectDir);
+    }
+
+    public TuiController(
+            List<RecipeInfo> allRecipes,
+            RunConfigService runConfigService,
+            RecipeExecutionEngine engine,
+            ProjectSourceParser sourceParser,
+            ChangeApplier changeApplier,
+            WorkspaceExecutionEngine workspaceEngine,
+            Path projectDir) {
+        this(
+                allRecipes,
+                runConfigService,
+                engine,
+                sourceParser,
+                changeApplier,
+                workspaceEngine,
+                workspaceEngine != null ? SessionHolder.getProjectEntries() : null,
+                projectDir);
+    }
+
+    public TuiController(
+            List<RecipeInfo> allRecipes,
+            RunConfigService runConfigService,
+            RecipeExecutionEngine engine,
+            ProjectSourceParser sourceParser,
+            ChangeApplier changeApplier,
+            WorkspaceExecutionEngine workspaceEngine,
+            List<ProjectEntry> workspaceProjects,
+            Path projectDir) {
         this.allRecipes = List.copyOf(allRecipes);
         this.runConfigService = runConfigService;
         this.engine = engine;
         this.sourceParser = sourceParser;
         this.changeApplier = changeApplier;
+        this.workspaceEngine = workspaceEngine;
+        this.workspaceProjects = workspaceProjects != null ? List.copyOf(workspaceProjects) : null;
         this.projectDir = projectDir;
         this.browserState = new RecipeListState(this::recipes, selectedRecipes);
     }
@@ -818,6 +858,11 @@ public class TuiController {
         return Optional.ofNullable(executionResult);
     }
 
+    @Requirements({"atunko:TUI_0002.4"})
+    public WorkspaceExecutionResult lastWorkspaceResult() {
+        return workspaceResult;
+    }
+
     public boolean lastRunWasDryRun() {
         return lastRunWasDryRun;
     }
@@ -852,6 +897,21 @@ public class TuiController {
         currentScreen = Screen.EXECUTION_RESULTS;
     }
 
+    @Requirements({"atunko:TUI_0002"})
+    public boolean isWorkspaceMode() {
+        return workspaceEngine != null;
+    }
+
+    @Requirements({"atunko:TUI_0002.2"})
+    public List<ProjectEntry> workspaceProjects() {
+        return workspaceProjects != null ? workspaceProjects : List.of();
+    }
+
+    @Requirements({"atunko:TUI_0002.5"})
+    public Path runsDir() {
+        return projectDir.resolve("atunko/runs");
+    }
+
     @Requirements({"atunko:TUI_0001.8"})
     public void showDryRunResult(ExecutionResult result) {
         this.executionResult = result;
@@ -872,12 +932,31 @@ public class TuiController {
         return projectDir;
     }
 
-    @Requirements({"atunko:TUI_0001.8", "atunko:TUI_0001.9"})
+    @Requirements({"atunko:TUI_0001.8", "atunko:TUI_0001.9", "atunko:TUI_0002.3"})
     public void runSelectedRecipes(boolean dryRun) {
+        LOG.fine(() -> "Running " + (dryRun ? "dry-run" : "execution") + " for " + runOrder.size() + " recipes");
+
+        List<String> recipesToRun =
+                runOrder.stream().filter(selectedRecipes::contains).toList();
+
+        if (isWorkspaceMode()) {
+            Workspace workspace = new Workspace(projectDir, workspaceProjects);
+            WorkspaceExecutionResult wsResult = workspaceEngine.execute(recipesToRun, workspace);
+            if (!dryRun && changeApplier != null) {
+                wsResult.results().stream()
+                        .filter(r -> r.succeeded() && r.result() != null)
+                        .forEach(r -> changeApplier.apply(
+                                r.entry().projectDir(), r.result().changes()));
+            }
+            this.workspaceResult = wsResult;
+            this.lastRunWasDryRun = dryRun;
+            this.currentScreen = Screen.WORKSPACE_RESULTS;
+            return;
+        }
+
         if (engine == null || sourceParser == null) {
             return;
         }
-        LOG.fine(() -> "Running " + (dryRun ? "dry-run" : "execution") + " for " + runOrder.size() + " recipes");
 
         List<SourceFile> sources;
         ProjectInfo projectInfo = SessionHolder.getProjectInfo();
@@ -886,10 +965,6 @@ public class TuiController {
         } else {
             sources = sourceParser.parse(new ProjectInfo(List.of(), List.of(projectDir)));
         }
-
-        // Use runOrder filtered to selected recipes, preserving user-defined execution order
-        List<String> recipesToRun =
-                runOrder.stream().filter(selectedRecipes::contains).toList();
 
         List<FileChange> allChanges = new ArrayList<>();
         for (String recipeName : recipesToRun) {
@@ -922,9 +997,9 @@ public class TuiController {
         browserState.resetHighlight();
     }
 
-    @Requirements({"atunko:TUI_0001.19"})
+    @Requirements({"atunko:TUI_0001.19", "atunko:TUI_0002.5"})
     public List<Path> listRunConfigs() {
-        Path dir = projectDir.resolve("atunko/runs");
+        Path dir = runsDir();
         if (!Files.isDirectory(dir)) {
             return List.of();
         }
@@ -1001,7 +1076,7 @@ public class TuiController {
             exitSaveConfigMode();
             return;
         }
-        Path dir = projectDir.resolve("atunko/runs");
+        Path dir = runsDir();
         Files.createDirectories(dir);
         saveRunConfig(dir.resolve(saveConfigName + ".yml"));
         exitSaveConfigMode();

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
@@ -9,13 +9,14 @@ import static dev.tamboui.toolkit.Toolkit.text;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
+import io.github.atunkodev.core.project.ProjectEntry;
 import io.github.atunkodev.tui.TuiController;
 import io.github.atunkodev.tui.TuiController.DisplayRow;
 import io.github.reqstool.annotations.Requirements;
 import java.util.List;
 import java.util.Set;
 
-@Requirements({"atunko:TUI_0001.14"})
+@Requirements({"atunko:TUI_0001.14", "atunko:TUI_0002.2"})
 public final class ConfirmRunView {
 
     private ConfirmRunView() {}
@@ -24,17 +25,13 @@ public final class ConfirmRunView {
         List<DisplayRow> displayRows = controller.runDisplayRows();
         Set<String> selected = controller.selectedRecipes();
         boolean hasRecipes = !displayRows.isEmpty();
-        String projectPath =
-                controller.projectDir().toAbsolutePath().normalize().toString();
 
         Element centerContent;
         if (controller.isShowHelp()) {
             centerContent = row(spacer(), HelpOverlay.render(HelpOverlay.RUN_DIALOG_HELP), spacer());
         } else if (hasRecipes) {
-            centerContent = column(
-                    row(text("Project: ").addClass("detail-label"), text(projectPath)),
-                    text(""),
-                    renderRecipeList(controller, displayRows, selected));
+            Element projectInfo = buildProjectInfo(controller);
+            centerContent = column(projectInfo, text(""), renderRecipeList(controller, displayRows, selected));
         } else {
             centerContent = column(
                     text(""),
@@ -63,6 +60,25 @@ public final class ConfirmRunView {
                 .id("confirm-run")
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, hasRecipes, event));
+    }
+
+    @Requirements({"atunko:TUI_0002.2"})
+    private static Element buildProjectInfo(TuiController controller) {
+        if (controller.isWorkspaceMode()) {
+            List<ProjectEntry> entries = controller.workspaceProjects();
+            Element[] projectLines = entries.stream()
+                    .map(e -> (Element) row(
+                            text("  • ").addClass("detail-label"),
+                            text(e.projectDir().getFileName().toString())))
+                    .toArray(Element[]::new);
+            Element[] headerAndProjects = new Element[projectLines.length + 1];
+            headerAndProjects[0] = row(text("Projects: ").addClass("detail-label"));
+            System.arraycopy(projectLines, 0, headerAndProjects, 1, projectLines.length);
+            return column(headerAndProjects);
+        }
+        String projectPath =
+                controller.projectDir().toAbsolutePath().normalize().toString();
+        return row(text("Project: ").addClass("detail-label"), text(projectPath));
     }
 
     private static Element renderRecipeList(

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
@@ -12,22 +12,73 @@ import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
+import io.github.atunkodev.core.engine.ProjectExecutionResult;
+import io.github.atunkodev.core.engine.WorkspaceExecutionResult;
 import io.github.atunkodev.tui.TuiController;
 import io.github.reqstool.annotations.Requirements;
 import java.util.List;
 
-@Requirements({"atunko:TUI_0001.8", "atunko:TUI_0001.9"})
+@Requirements({"atunko:TUI_0001.8", "atunko:TUI_0001.9", "atunko:TUI_0002.4"})
 public final class ExecutionResultsView {
 
     private ExecutionResultsView() {}
 
     public static Element render(TuiController controller) {
+        WorkspaceExecutionResult wsResult = controller.lastWorkspaceResult();
+        if (wsResult != null) {
+            return renderWorkspaceResult(controller, wsResult);
+        }
         String title = controller.lastRunWasDryRun() ? "Dry-Run Preview" : "Execution Results";
-
         return controller
                 .executionResult()
                 .map(result -> renderResult(controller, title, result))
                 .orElse(text("No results"));
+    }
+
+    @Requirements({"atunko:TUI_0002.4"})
+    private static Element renderWorkspaceResult(TuiController controller, WorkspaceExecutionResult wsResult) {
+        String title = controller.lastRunWasDryRun() ? "Dry-Run Preview" : "Workspace Results";
+        var titleElement = controller.lastRunWasDryRun()
+                ? text(" " + title + " ").addClass("screen-title", "dryrun-mode")
+                : text(" " + title + " ").addClass("screen-title", "success-mode");
+
+        long total = wsResult.totalChanges();
+        long failures = wsResult.failureCount();
+        String summary = total + " change(s)";
+        if (failures > 0) {
+            summary += ", " + failures + " failure(s)";
+        }
+
+        List<String> rows =
+                wsResult.results().stream().map(r -> formatProjectRow(r)).toList();
+
+        return column(dock().top(
+                                row(titleElement, spacer(), text(summary + " ").addClass("coverage-indicator")),
+                                Constraint.length(1))
+                        .center(list(rows)
+                                .title("Project Results")
+                                .addClass("panel")
+                                .autoScroll())
+                        .bottom(text(" Esc/q:back").addClass("status-bar"), Constraint.length(1))
+                        .constraint(Constraint.fill()))
+                .id("workspace-results")
+                .focusable()
+                .onKeyEvent(event -> {
+                    if (event.isChar('q') || event.code() == dev.tamboui.tui.event.KeyCode.ESCAPE) {
+                        controller.goBack();
+                        return EventResult.HANDLED;
+                    }
+                    return EventResult.UNHANDLED;
+                });
+    }
+
+    private static String formatProjectRow(ProjectExecutionResult r) {
+        String projectName = r.entry().projectDir().getFileName().toString();
+        if (r.succeeded()) {
+            int changes = r.result() != null ? r.result().changes().size() : 0;
+            return String.format("%-40s  %4d change(s)  PASS", projectName, changes);
+        }
+        return String.format("%-40s     -           FAIL", projectName);
     }
 
     private static Element renderResult(TuiController controller, String title, ExecutionResult result) {

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -6,6 +6,12 @@ import io.github.atunkodev.core.config.RunConfig;
 import io.github.atunkodev.core.config.RunConfigService;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
+import io.github.atunkodev.core.engine.ProjectExecutionResult;
+import io.github.atunkodev.core.engine.WorkspaceExecutionEngine;
+import io.github.atunkodev.core.engine.WorkspaceExecutionResult;
+import io.github.atunkodev.core.project.ProjectEntry;
+import io.github.atunkodev.core.project.ProjectInfo;
+import io.github.atunkodev.core.project.Workspace;
 import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.core.recipe.SortOrder;
 import io.github.atunkodev.tui.TuiController.DisplayRow;
@@ -1642,5 +1648,55 @@ class TuiControllerTest {
         assertThat(rows.get(2).path()).isEqualTo("org.test.Composite/org.test.Sub1");
         assertThat(rows.get(3).path()).isEqualTo("org.test.Composite/org.test.Sub2");
         assertThat(rows.get(4).path()).isEqualTo("org.test.Gamma");
+    }
+
+    // --- Workspace execution ---
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0002.3"})
+    void runSelectedRecipesInWorkspaceModeStoresWorkspaceResultAndNavigatesToWorkspaceResultsScreen(
+            @TempDir Path workspaceDir, @TempDir Path projectA, @TempDir Path projectB) {
+        ProjectInfo info = new ProjectInfo(List.of(), List.of());
+        ProjectEntry entryA = new ProjectEntry(projectA, info);
+        ProjectEntry entryB = new ProjectEntry(projectB, info);
+        List<ProjectEntry> entries = List.of(entryA, entryB);
+
+        WorkspaceExecutionResult fakeResult = new WorkspaceExecutionResult(List.of(
+                new ProjectExecutionResult(entryA, new ExecutionResult(List.of()), null),
+                new ProjectExecutionResult(
+                        entryB, new ExecutionResult(List.of(new FileChange(Path.of("Foo.java"), "a", "b"))), null)));
+
+        WorkspaceExecutionEngine stubEngine = new WorkspaceExecutionEngine(null, null) {
+            @Override
+            public WorkspaceExecutionResult execute(List<String> recipeNames, Workspace workspace) {
+                return fakeResult;
+            }
+        };
+
+        TuiController controller =
+                new TuiController(RECIPES, new RunConfigService(), null, null, null, stubEngine, entries, workspaceDir);
+        controller.toggleSelection(); // select Alpha
+        controller.openConfirmRun();
+
+        controller.runSelectedRecipes(false);
+
+        assertThat(controller.currentScreen()).isEqualTo(Screen.WORKSPACE_RESULTS);
+        assertThat(controller.lastWorkspaceResult()).isSameAs(fakeResult);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0002.5"})
+    void runsDirUsesWorkspaceRootWhenInWorkspaceMode(@TempDir Path workspaceDir) {
+        TuiController controller = new TuiController(RECIPES, new RunConfigService(), null, null, null, workspaceDir);
+
+        assertThat(controller.runsDir()).isEqualTo(workspaceDir.resolve("atunko/runs"));
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0002.5"})
+    void runsDirUsesProjectDirWhenInSingleProjectMode(@TempDir Path projectDir) {
+        TuiController controller = new TuiController(RECIPES, new RunConfigService(), null, null, null, projectDir);
+
+        assertThat(controller.runsDir()).isEqualTo(projectDir.resolve("atunko/runs"));
     }
 }

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/view/ExecutionResultsViewTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/view/ExecutionResultsViewTest.java
@@ -1,0 +1,89 @@
+package io.github.atunkodev.tui.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.toolkit.element.Element;
+import io.github.atunkodev.core.engine.ExecutionResult;
+import io.github.atunkodev.core.engine.FileChange;
+import io.github.atunkodev.core.engine.ProjectExecutionResult;
+import io.github.atunkodev.core.engine.WorkspaceExecutionEngine;
+import io.github.atunkodev.core.engine.WorkspaceExecutionResult;
+import io.github.atunkodev.core.project.ProjectEntry;
+import io.github.atunkodev.core.project.ProjectInfo;
+import io.github.atunkodev.core.project.Workspace;
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.atunkodev.tui.Screen;
+import io.github.atunkodev.tui.TuiController;
+import io.github.reqstool.annotations.SVCs;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SVCs({"atunko:SVC_TUI_0002.4"})
+class ExecutionResultsViewTest {
+
+    private static final RecipeInfo ALPHA =
+            new RecipeInfo("org.test.Alpha", "Alpha Recipe", "First recipe", Set.of("java"));
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0002.4"})
+    void renderReturnsNonNullElementForWorkspaceResult(@TempDir Path workspaceDir, @TempDir Path projectA) {
+        ProjectInfo info = new ProjectInfo(List.of(), List.of());
+        ProjectEntry entryA = new ProjectEntry(projectA, info);
+        List<ProjectEntry> entries = List.of(entryA);
+
+        WorkspaceExecutionResult fakeResult = new WorkspaceExecutionResult(List.of(new ProjectExecutionResult(
+                entryA, new ExecutionResult(List.of(new FileChange(Path.of("Foo.java"), "a", "b"))), null)));
+
+        WorkspaceExecutionEngine stubEngine = new WorkspaceExecutionEngine(null, null) {
+            @Override
+            public WorkspaceExecutionResult execute(List<String> recipeNames, Workspace workspace) {
+                return fakeResult;
+            }
+        };
+
+        TuiController controller =
+                new TuiController(List.of(ALPHA), null, null, null, null, stubEngine, entries, workspaceDir);
+        controller.toggleSelection();
+        controller.openConfirmRun();
+        controller.runSelectedRecipes(false);
+
+        assertThat(controller.currentScreen()).isEqualTo(Screen.WORKSPACE_RESULTS);
+        assertThat(controller.lastWorkspaceResult()).isNotNull();
+        assertThat(controller.lastWorkspaceResult().results()).hasSize(1);
+        assertThat(controller.lastWorkspaceResult().results().getFirst().succeeded())
+                .isTrue();
+
+        Element rendered = ExecutionResultsView.render(controller);
+        assertThat(rendered).isNotNull();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0002.4"})
+    void renderShowsFailureInWorkspaceResult(@TempDir Path workspaceDir, @TempDir Path projectA) {
+        ProjectInfo info = new ProjectInfo(List.of(), List.of());
+        ProjectEntry entryA = new ProjectEntry(projectA, info);
+        List<ProjectEntry> entries = List.of(entryA);
+
+        WorkspaceExecutionResult fakeResult = new WorkspaceExecutionResult(
+                List.of(new ProjectExecutionResult(entryA, null, new RuntimeException("build failure"))));
+
+        WorkspaceExecutionEngine stubEngine = new WorkspaceExecutionEngine(null, null) {
+            @Override
+            public WorkspaceExecutionResult execute(List<String> recipeNames, Workspace workspace) {
+                return fakeResult;
+            }
+        };
+
+        TuiController controller =
+                new TuiController(List.of(ALPHA), null, null, null, null, stubEngine, entries, workspaceDir);
+        controller.toggleSelection();
+        controller.openConfirmRun();
+        controller.runSelectedRecipes(false);
+
+        assertThat(controller.lastWorkspaceResult().hasFailures()).isTrue();
+        assertThat(ExecutionResultsView.render(controller)).isNotNull();
+    }
+}

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -892,3 +892,72 @@ requirements:
       requirement_ids: ["WEB_0002"]
     categories: [interaction-capability]
     revision: 0.1.0
+
+  # TUI workspace requirements
+  - id: TUI_0002
+    title: TUI Workspace Support
+    significance: shall
+    description: >-
+      The TUI shall support a --workspace option that scans a root directory for
+      projects and initialises a multi-project session, allowing recipe execution
+      across all discovered projects
+    categories: [functional-suitability]
+    revision: 0.1.0
+
+  - id: TUI_0002.1
+    title: TUI — --workspace Option
+    significance: shall
+    description: >-
+      The TUI subcommand shall accept a --workspace <path> option that is mutually
+      exclusive with --project-dir; when supplied it scans the path with
+      WorkspaceScanner and calls SessionHolder.initWorkspace()
+    references:
+      requirement_ids: ["TUI_0002"]
+    categories: [functional-suitability]
+    revision: 0.1.0
+
+  - id: TUI_0002.2
+    title: TUI — Run Dialog Shows All Workspace Projects
+    significance: shall
+    description: >-
+      When in workspace mode the Run Recipes dialog shall display the list of all
+      discovered project directory names instead of the single-project path line
+    references:
+      requirement_ids: ["TUI_0002"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: TUI_0002.3
+    title: TUI — Workspace Execution via WorkspaceExecutionEngine
+    significance: shall
+    description: >-
+      When in workspace mode the TUI shall execute selected recipes across all
+      workspace projects using WorkspaceExecutionEngine and navigate to the
+      WORKSPACE_RESULTS screen on completion
+    references:
+      requirement_ids: ["TUI_0002"]
+    categories: [functional-suitability]
+    revision: 0.1.0
+
+  - id: TUI_0002.4
+    title: TUI — Aggregate Workspace Results Screen
+    significance: shall
+    description: >-
+      After a workspace run the TUI shall display a per-project results table
+      showing each project directory name, the number of changed files, and
+      pass/fail status for each project
+    references:
+      requirement_ids: ["TUI_0002"]
+    categories: [interaction-capability]
+    revision: 0.1.0
+
+  - id: TUI_0002.5
+    title: TUI — Workspace Config Directory
+    significance: shall
+    description: >-
+      When in workspace mode run configurations shall be saved to and loaded from
+      <workspaceRoot>/atunko/runs/ rather than the single-project directory
+    references:
+      requirement_ids: ["TUI_0002"]
+    categories: [functional-suitability]
+    revision: 0.1.0

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -1228,3 +1228,64 @@ cases:
       WHEN buildReverseIndex is called with that list
       THEN each sub-recipe is mapped to the composites that directly contain it
     revision: "0.1.0"
+
+  - id: SVC_TUI_0002
+    requirement_ids: ["TUI_0002"]
+    title: TUI workspace session initialised from --workspace flag
+    verification: automated-test
+    description: |
+      GIVEN a directory containing multiple projects
+      WHEN the TUI is launched with --workspace pointing to that directory
+      THEN SessionHolder is initialised in workspace mode with all discovered projects
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0002.1
+    requirement_ids: ["TUI_0002.1"]
+    title: TuiCommand --workspace option is mutually exclusive with --project-dir
+    verification: automated-test
+    description: |
+      GIVEN TuiCommand is invoked with both --workspace and --project-dir
+      WHEN the command line is parsed
+      THEN an error is reported and the TUI does not launch
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0002.2
+    requirement_ids: ["TUI_0002.2"]
+    title: Run dialog lists all workspace project names in workspace mode
+    verification: automated-test
+    description: |
+      GIVEN the TUI is in workspace mode with multiple discovered projects
+      WHEN the Run Recipes dialog is rendered
+      THEN the header area lists all project directory names instead of a single path
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0002.3
+    requirement_ids: ["TUI_0002.3"]
+    title: TUI executes recipes via WorkspaceExecutionEngine in workspace mode
+    verification: automated-test
+    description: |
+      GIVEN the TUI is in workspace mode and recipes are selected
+      WHEN the user triggers execution
+      THEN WorkspaceExecutionEngine.execute() is called and the result is stored as lastWorkspaceResult
+      AND the screen transitions to WORKSPACE_RESULTS
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0002.4
+    requirement_ids: ["TUI_0002.4"]
+    title: Workspace results screen shows per-project table
+    verification: automated-test
+    description: |
+      GIVEN a workspace run has completed
+      WHEN the WORKSPACE_RESULTS screen is rendered
+      THEN each project appears as a row with its directory name, changed-file count, and PASS or FAIL status
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0002.5
+    requirement_ids: ["TUI_0002.5"]
+    title: Run configs stored under workspaceRoot in workspace mode
+    verification: automated-test
+    description: |
+      GIVEN the TUI is in workspace mode
+      WHEN a run configuration is saved or the config list is queried
+      THEN the directory used is workspaceRoot/atunko/runs/ not the single-project directory
+    revision: "0.1.0"

--- a/openspec/changes/tui-workspace-support-12/.openspec.yaml
+++ b/openspec/changes/tui-workspace-support-12/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/tui-workspace-support-12/design.md
+++ b/openspec/changes/tui-workspace-support-12/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Core (CORE_0010/0011/0012), CLI (CLI_0005), and Web UI (WEB_0002) already support workspace mode. The TUI subcommand (`atunko tui`) is the only surface without it. All necessary engine APIs (`WorkspaceScanner`, `WorkspaceExecutionEngine`, `WorkspaceExecutionResult`, `SessionHolder.initWorkspace()`) are already in `atunko-core`. The TUI only needs wiring and display changes.
+
+Current single-project flow: `TuiCommand` → `SessionHolder.init(dir, info)` → `TuiController` executes via `RecipeExecutionEngine` → `ExecutionResultsView` shows changed files.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `--workspace <path>` option to `TuiCommand` (mirrors CLI/Web)
+- Route TUI execution through `WorkspaceExecutionEngine` when workspace mode is active
+- Show all workspace projects in `ConfirmRunView` before execution
+- Show per-project PASS/FAIL results table after execution (`WORKSPACE_RESULTS` screen)
+- Store run configs under `<workspaceRoot>/atunko/runs/` in workspace mode
+
+**Non-Goals:**
+- Per-project recipe browsing / project-switching screen (not in CLI or Web MVP)
+- Partial project selection (run against a subset of workspace projects)
+- Parallel project execution (serial, same as `WorkspaceExecutionEngine`)
+
+## Decisions
+
+### D1 — No new project-selector screen
+Single recipe browser that works across all workspace projects, same as in CLI/Web. The ConfirmRunView summarises which projects will be targeted; users see the full list before executing.
+
+**Alternatives considered:** A dedicated `PROJECT_SELECTOR` screen before `BROWSER`. Rejected — adds complexity with no clear benefit for the MVP; CLI and Web don't have one either.
+
+### D2 — `WORKSPACE_RESULTS` screen is a new `Screen` enum value, not a flag on `EXECUTION_RESULTS`
+Clean separation keeps `ExecutionResultsView` render logic readable: it inspects `controller.lastWorkspaceResult()` (non-null → workspace table) vs `controller.lastExecutionResult()` (non-null → single-project list). Both paths live in `ExecutionResultsView`; `AtunkoTui` routes `WORKSPACE_RESULTS` there.
+
+**Alternatives considered:** Reuse `EXECUTION_RESULTS` with a mode flag. Rejected — complicates view dispatch and the `Screen` enum already encodes screen identity.
+
+### D3 — `TuiController` is the workspace/single-project router
+`TuiController.runSelectedRecipes(boolean dryRun)` checks `SessionHolder.getWorkspaceRoot() != null`. If true, it builds a `Workspace` from `SessionHolder.getProjectEntries()` and delegates to `WorkspaceExecutionEngine`; result stored as `lastWorkspaceResult`. Otherwise, existing single-project path is unchanged.
+
+### D4 — Config directory follows `SessionHolder.getWorkspaceRoot()`
+`TuiController.runsDir()` returns `workspaceRoot.resolve("atunko/runs")` when workspace mode is active, `projectDir.resolve("atunko/runs")` otherwise. This matches `CORE_0012` (workspace run-config block) and how CLI handles it.
+
+### D5 — `TuiCommand` option group: `--workspace` mutually exclusive with `--project-dir`
+Picocli `@ArgGroup(exclusive = true)` — same pattern as `RunCommand`. Default: single-project mode with `--project-dir` defaulting to `.`.
+
+## Risks / Trade-offs
+
+- [Risk] `WorkspaceExecutionEngine` runs projects serially — large workspaces may feel slow in the TUI. → Mitigation: out of scope; match existing CLI/Web behaviour.
+- [Risk] `ConfirmRunView` "Project" line currently uses `controller.projectDir()` — if workspace mode isn't checked, a NullPointerException could surface. → Mitigation: guard in `ConfirmRunView` before reading `projectDir()`.
+- [Risk] `ExecutionResultsView` currently assumes a flat `List<Path>` of changed files. Workspace results have a different shape. → Mitigation: `controller.lastWorkspaceResult()` accessor added; view checks at render time.
+
+## Migration Plan
+
+No migration needed. The `--workspace` option is additive; existing `--project-dir` invocations are unaffected.

--- a/openspec/changes/tui-workspace-support-12/proposal.md
+++ b/openspec/changes/tui-workspace-support-12/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+PR #52 shipped workspace (multi-project) support for core, CLI, and web UI, but the TUI subcommand was left out. Users who invoke `atunko tui` from a multi-project workspace cannot browse, select, and execute recipes across all projects the way `atunko run --workspace` and `atunko webui --workspace` already can.
+
+## What Changes
+
+- `TuiCommand` gains a `--workspace <path>` option (mutually exclusive with `--project-dir`) that scans the workspace and calls `SessionHolder.initWorkspace()`.
+- `TuiController` gains workspace-mode awareness: detects multi-project state via `SessionHolder`, routes execution through `WorkspaceExecutionEngine`, and stores run configs under `<workspaceRoot>/atunko/runs/`.
+- `Screen` enum gains a `WORKSPACE_RESULTS` entry for the post-execution workspace summary screen.
+- `ConfirmRunView` shows all workspace projects when in workspace mode instead of the single "Project: `<path>`" line.
+- `ExecutionResultsView` renders a per-project results table (project name | change count | PASS/FAIL) in workspace mode; single-project mode is unchanged.
+- `AtunkoTui` routes the `WORKSPACE_RESULTS` screen to the updated `ExecutionResultsView`.
+- New `TUI_0002` requirement family added to reqstool for TUI workspace support.
+
+## Capabilities
+
+### New Capabilities
+
+- `tui-workspace-support`: TUI workspace mode — `--workspace` option, multi-project execution, per-project results screen.
+
+### Modified Capabilities
+
+- `tui-launch`: `TuiCommand` gains a new CLI option; no requirement-level behavior change to existing single-project flow.
+
+## Impact
+
+- **atunko-tui**: `TuiCommand`, `TuiController`, `Screen`, `ConfirmRunView`, `ExecutionResultsView`, `AtunkoTui` — all modified.
+- **atunko-core**: no changes (all engine/session APIs already exist).
+- **atunko-cli**: no changes (TuiCommand lives in atunko-tui; App.java is unchanged).
+- **atunko-web**: no changes.
+- **reqstool**: new `TUI_0002` requirements and SVCs added to `docs/reqstool/`.
+- **Dependencies**: `WorkspaceExecutionEngine`, `WorkspaceScanner`, `WorkspaceExecutionResult`, `ProjectExecutionResult` — already in core, just wired into TUI.

--- a/openspec/changes/tui-workspace-support-12/specs/tui-workspace-support/spec.md
+++ b/openspec/changes/tui-workspace-support-12/specs/tui-workspace-support/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: TUI_0002
+The system SHALL implement TUI_0002.
+
+#### Scenario: SVC_TUI_0002
+The system SHALL pass SVC_TUI_0002.
+
+### Requirement: TUI_0002.1
+The system SHALL implement TUI_0002.1.
+
+#### Scenario: SVC_TUI_0002.1
+The system SHALL pass SVC_TUI_0002.1.
+
+### Requirement: TUI_0002.2
+The system SHALL implement TUI_0002.2.
+
+#### Scenario: SVC_TUI_0002.2
+The system SHALL pass SVC_TUI_0002.2.
+
+### Requirement: TUI_0002.3
+The system SHALL implement TUI_0002.3.
+
+#### Scenario: SVC_TUI_0002.3
+The system SHALL pass SVC_TUI_0002.3.
+
+### Requirement: TUI_0002.4
+The system SHALL implement TUI_0002.4.
+
+#### Scenario: SVC_TUI_0002.4
+The system SHALL pass SVC_TUI_0002.4.
+
+### Requirement: TUI_0002.5
+The system SHALL implement TUI_0002.5.
+
+#### Scenario: SVC_TUI_0002.5
+The system SHALL pass SVC_TUI_0002.5.

--- a/openspec/changes/tui-workspace-support-12/tasks.md
+++ b/openspec/changes/tui-workspace-support-12/tasks.md
@@ -1,0 +1,46 @@
+## 1. reqstool — Add TUI_0002 Requirements and SVCs
+
+- [x] 1.1 Add TUI_0002 (TUI Workspace Support — top-level) requirement and SVC_TUI_0002 to `docs/reqstool/requirements.yml` and `docs/reqstool/software_verification_cases.yml`
+- [x] 1.2 Add TUI_0002.1 (TUI — `--workspace` Option) requirement and SVC_TUI_0002.1 (covers `TuiCommand` option parsing and `SessionHolder.initWorkspace()` call)
+- [x] 1.3 Add TUI_0002.2 (TUI — Run Dialog Shows All Workspace Projects) requirement and SVC_TUI_0002.2
+- [x] 1.4 Add TUI_0002.3 (TUI — Workspace Execution via `WorkspaceExecutionEngine`) requirement and SVC_TUI_0002.3
+- [x] 1.5 Add TUI_0002.4 (TUI — Aggregate Workspace Results Screen) requirement and SVC_TUI_0002.4
+- [x] 1.6 Add TUI_0002.5 (TUI — Workspace Config Directory) requirement and SVC_TUI_0002.5
+
+## 2. TuiCommand — `--workspace` Option
+
+- [x] 2.1 Add `--workspace Path` option to `TuiCommand` in an `@ArgGroup(exclusive = true)` with `--project-dir` (covers TUI_0002.1 / SVC_TUI_0002.1)
+- [x] 2.2 When `--workspace` is supplied, scan with `WorkspaceScanner.scan(workspaceDir)` and call `SessionHolder.initWorkspace(workspace.root(), workspace.projects())`
+- [x] 2.3 Keep existing `--project-dir` / `SessionHolder.init()` path unchanged
+
+## 3. TuiController — Workspace Mode
+
+- [x] 3.1 Add `lastWorkspaceResult` field (`WorkspaceExecutionResult`) and accessor to `TuiController`
+- [x] 3.2 Add `runsDir()` helper: returns `workspaceRoot/atunko/runs` when workspace mode active, `projectDir/atunko/runs` otherwise (covers TUI_0002.5 / SVC_TUI_0002.5)
+- [x] 3.3 In `runSelectedRecipes(boolean dryRun)`: when `SessionHolder.getWorkspaceRoot() != null`, build `Workspace` from `SessionHolder.getProjectEntries()` and execute via `WorkspaceExecutionEngine`; store result in `lastWorkspaceResult` and navigate to `Screen.WORKSPACE_RESULTS` (covers TUI_0002.3 / SVC_TUI_0002.3)
+- [x] 3.4 Replace hardcoded `projectDir.resolve("atunko/runs")` references in `listRunConfigs()` and `saveRunConfig()` with `runsDir()`
+- [x] 3.5 Write unit tests for `TuiController` workspace execution path annotated with `@SVCs("SVC_TUI_0002.3")`
+
+## 4. Screen Enum
+
+- [x] 4.1 Add `WORKSPACE_RESULTS` to the `Screen` enum in `atunko-tui`
+
+## 5. ConfirmRunView — Workspace Project List
+
+- [x] 5.1 In `ConfirmRunView`, when `SessionHolder.getWorkspaceRoot() != null`, render a list of all `ProjectEntry` names instead of the single "Project: `<path>`" line (covers TUI_0002.2 / SVC_TUI_0002.2)
+- [x] 5.2 Guard `controller.projectDir()` access in `ConfirmRunView` so it is only called in single-project mode
+
+## 6. ExecutionResultsView — Workspace Results Table
+
+- [x] 6.1 In `ExecutionResultsView`, check `controller.lastWorkspaceResult() != null`; if so, render a per-project table: project directory name | change count | PASS / FAIL (covers TUI_0002.4 / SVC_TUI_0002.4)
+- [x] 6.2 Keep existing single-project flat file list path unchanged
+- [x] 6.3 Write unit test for workspace results rendering annotated with `@SVCs("SVC_TUI_0002.4")`
+
+## 7. AtunkoTui — Route WORKSPACE_RESULTS Screen
+
+- [x] 7.1 In `AtunkoTui` screen dispatch, add a `case WORKSPACE_RESULTS` that renders `ExecutionResultsView` (workspace path)
+
+## 8. Build & Quality
+
+- [x] 8.1 Run `./gradlew spotlessApply` and fix any formatting issues
+- [x] 8.2 Run `./gradlew build` and confirm zero errors / test failures


### PR DESCRIPTION
## Summary

- Adds `--workspace <path>` option to `TuiCommand` (mutually exclusive with `--project-dir`); scans via `WorkspaceScanner` and calls `SessionHolder.initWorkspace()`
- `TuiController` gains workspace-mode awareness: `WorkspaceExecutionEngine` routing, `lastWorkspaceResult()`, `runsDir()` respects workspace root, `isWorkspaceMode()` / `workspaceProjects()` accessors
- `Screen.WORKSPACE_RESULTS` added; `AtunkoTui` routes it to `ExecutionResultsView`
- `ConfirmRunView` shows all workspace project names (bullet list) when in workspace mode
- `ExecutionResultsView` renders a per-project table (name | change count | PASS/FAIL) for workspace results; single-project path unchanged
- `TUI_0002`–`TUI_0002.5` requirements and SVCs added to reqstool
- OpenSpec change `tui-workspace-support-12` (proposal / design / specs / tasks)

## Test plan

- [x] `TuiControllerTest` — workspace execution routes to `WORKSPACE_RESULTS` screen and stores `WorkspaceExecutionResult`
- [x] `TuiControllerTest` — `runsDir()` returns workspace root path in workspace mode, project dir otherwise
- [x] `ExecutionResultsViewTest` — workspace results render non-null element (passing projects)
- [x] `ExecutionResultsViewTest` — workspace results render non-null element (failing projects)
- [x] All existing 109 TUI tests continue to pass
- [x] Full build (`./gradlew build`) passes with zero errors

Closes #12