### PR TITLE
feat(tui): export run config to Maven/Gradle snippet (#9)

### DIFF
--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -1,5 +1,6 @@
 package io.github.atunkodev.tui;
 
+import io.github.atunkodev.core.config.ConfigExportService;
 import io.github.atunkodev.core.config.RecipeEntry;
 import io.github.atunkodev.core.config.RunConfig;
 import io.github.atunkodev.core.config.RunConfigService;
@@ -1044,6 +1045,62 @@ public class TuiController {
         RunConfig config = runConfigService.load(configFiles.get(loadConfigHighlightIndex));
         loadRunConfig(config);
         currentScreen = Screen.BROWSER;
+    }
+
+    // Export state
+    public enum ExportFormat {
+        GRADLE,
+        MAVEN
+    }
+
+    private ExportFormat exportFormat = ExportFormat.GRADLE;
+    private ConfigExportService.ExportMode exportMode = ConfigExportService.ExportMode.MINIMAL;
+    private boolean showExport = false;
+
+    @Requirements({"atunko:TUI_0001.21"})
+    public boolean isShowExport() {
+        return showExport;
+    }
+
+    @Requirements({"atunko:TUI_0001.21"})
+    public void openExport() {
+        this.showExport = true;
+    }
+
+    @Requirements({"atunko:TUI_0001.21"})
+    public void closeExport() {
+        this.showExport = false;
+    }
+
+    @Requirements({"atunko:TUI_0001.22"})
+    public ExportFormat exportFormat() {
+        return exportFormat;
+    }
+
+    @Requirements({"atunko:TUI_0001.22"})
+    public void setExportFormat(ExportFormat format) {
+        this.exportFormat = format;
+    }
+
+    @Requirements({"atunko:TUI_0001.23"})
+    public ConfigExportService.ExportMode exportMode() {
+        return exportMode;
+    }
+
+    @Requirements({"atunko:TUI_0001.23"})
+    public void toggleExportMode() {
+        this.exportMode = exportMode == ConfigExportService.ExportMode.MINIMAL
+                ? ConfigExportService.ExportMode.FULL
+                : ConfigExportService.ExportMode.MINIMAL;
+    }
+
+    @Requirements({"atunko:TUI_0001.21"})
+    public RunConfig buildRunConfig() {
+        List<RecipeEntry> entries = runOrder.stream()
+                .filter(selectedRecipes::contains)
+                .map(RecipeEntry::new)
+                .toList();
+        return new RunConfig(entries);
     }
 
     private boolean saveConfigMode = false;

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
@@ -16,12 +16,16 @@ import io.github.reqstool.annotations.Requirements;
 import java.util.List;
 import java.util.Set;
 
-@Requirements({"atunko:TUI_0001.14", "atunko:TUI_0002.2"})
+@Requirements({"atunko:TUI_0001.14", "atunko:TUI_0001.21", "atunko:TUI_0002.2"})
 public final class ConfirmRunView {
 
     private ConfirmRunView() {}
 
     public static Element render(TuiController controller) {
+        if (controller.isShowExport()) {
+            return ExportConfigView.render(controller);
+        }
+
         List<DisplayRow> displayRows = controller.runDisplayRows();
         Set<String> selected = controller.selectedRecipes();
         boolean hasRecipes = !displayRows.isEmpty();
@@ -44,7 +48,7 @@ public final class ConfirmRunView {
                 .count();
         long totalCount = displayRows.size();
         String footer = hasRecipes
-                ? selectedCount + "/" + totalCount + " selected | f:flatten F:flatten-all ?:help Esc:back"
+                ? selectedCount + "/" + totalCount + " selected | f:flatten F:flatten-all x:export ?:help Esc:back"
                 : "Esc:back";
 
         return column(dock().top(
@@ -156,6 +160,10 @@ public final class ConfirmRunView {
             }
             if (event.isChar('d')) {
                 controller.runSelectedRecipes(true);
+                return EventResult.HANDLED;
+            }
+            if (event.isChar('x')) {
+                controller.openExport();
                 return EventResult.HANDLED;
             }
         }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExportConfigView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExportConfigView.java
@@ -1,0 +1,79 @@
+package io.github.atunkodev.tui.view;
+
+import static dev.tamboui.toolkit.Toolkit.column;
+import static dev.tamboui.toolkit.Toolkit.dock;
+import static dev.tamboui.toolkit.Toolkit.markupTextArea;
+import static dev.tamboui.toolkit.Toolkit.row;
+import static dev.tamboui.toolkit.Toolkit.spacer;
+import static dev.tamboui.toolkit.Toolkit.text;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.event.EventResult;
+import io.github.atunkodev.core.config.ConfigExportService;
+import io.github.atunkodev.core.config.RunConfig;
+import io.github.atunkodev.tui.TuiController;
+import io.github.reqstool.annotations.Requirements;
+
+@Requirements({"atunko:TUI_0001.21", "atunko:TUI_0001.22", "atunko:TUI_0001.23"})
+public final class ExportConfigView {
+
+    private static final ConfigExportService EXPORT_SERVICE = new ConfigExportService();
+
+    private ExportConfigView() {}
+
+    public static Element render(TuiController controller) {
+        RunConfig config = controller.buildRunConfig();
+        TuiController.ExportFormat format = controller.exportFormat();
+        ConfigExportService.ExportMode mode = controller.exportMode();
+
+        String snippet = format == TuiController.ExportFormat.GRADLE
+                ? EXPORT_SERVICE.exportToGradle(config, mode)
+                : EXPORT_SERVICE.exportToMaven(config, mode);
+
+        String formatLabel = format == TuiController.ExportFormat.GRADLE ? "Gradle" : "Maven";
+        String modeLabel = mode == ConfigExportService.ExportMode.MINIMAL ? "Minimal" : "Full";
+
+        return column(dock().top(
+                                row(
+                                        text(" Export Config ").addClass("screen-title"),
+                                        spacer(),
+                                        text(" " + formatLabel + " · " + modeLabel + " ")
+                                                .addClass("detail-value")),
+                                Constraint.length(1))
+                        .center(markupTextArea(snippet)
+                                .title(formatLabel + " snippet")
+                                .showLineNumbers()
+                                .scrollbar()
+                                .wrapWord()
+                                .constraint(Constraint.fill()))
+                        .bottom(
+                                text(" g:Gradle  m:Maven  Tab:Minimal/Full  Esc:close")
+                                        .addClass("status-bar"),
+                                Constraint.length(1))
+                        .constraint(Constraint.fill()))
+                .id("export-config")
+                .focusable()
+                .onKeyEvent(event -> handleKeyEvent(controller, event));
+    }
+
+    private static EventResult handleKeyEvent(TuiController controller, dev.tamboui.tui.event.KeyEvent event) {
+        if (event.isChar('g')) {
+            controller.setExportFormat(TuiController.ExportFormat.GRADLE);
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('m')) {
+            controller.setExportFormat(TuiController.ExportFormat.MAVEN);
+            return EventResult.HANDLED;
+        }
+        if (event.code() == dev.tamboui.tui.event.KeyCode.TAB) {
+            controller.toggleExportMode();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('q') || event.code() == dev.tamboui.tui.event.KeyCode.ESCAPE) {
+            controller.closeExport();
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
+    }
+}

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -1699,4 +1699,46 @@ class TuiControllerTest {
 
         assertThat(controller.runsDir()).isEqualTo(projectDir.resolve("atunko/runs"));
     }
+
+    // --- Export config state ---
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.21"})
+    void defaultExportStateIsGradleMinimalAndClosed() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.exportFormat()).isEqualTo(TuiController.ExportFormat.GRADLE);
+        assertThat(controller.exportMode())
+                .isEqualTo(io.github.atunkodev.core.config.ConfigExportService.ExportMode.MINIMAL);
+        assertThat(controller.isShowExport()).isFalse();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.22"})
+    void setExportFormatTogglesFormat() {
+        TuiController controller = new TuiController(RECIPES);
+
+        controller.setExportFormat(TuiController.ExportFormat.MAVEN);
+        assertThat(controller.exportFormat()).isEqualTo(TuiController.ExportFormat.MAVEN);
+
+        controller.setExportFormat(TuiController.ExportFormat.GRADLE);
+        assertThat(controller.exportFormat()).isEqualTo(TuiController.ExportFormat.GRADLE);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.23"})
+    void toggleExportModeCyclesMinimalAndFull() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.exportMode())
+                .isEqualTo(io.github.atunkodev.core.config.ConfigExportService.ExportMode.MINIMAL);
+
+        controller.toggleExportMode();
+        assertThat(controller.exportMode())
+                .isEqualTo(io.github.atunkodev.core.config.ConfigExportService.ExportMode.FULL);
+
+        controller.toggleExportMode();
+        assertThat(controller.exportMode())
+                .isEqualTo(io.github.atunkodev.core.config.ConfigExportService.ExportMode.MINIMAL);
+    }
 }

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/view/ExportConfigViewTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/view/ExportConfigViewTest.java
@@ -1,0 +1,63 @@
+package io.github.atunkodev.tui.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.toolkit.element.Element;
+import io.github.atunkodev.core.config.ConfigExportService;
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.atunkodev.tui.TuiController;
+import io.github.reqstool.annotations.SVCs;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+@SVCs({"atunko:SVC_TUI_0001.21"})
+class ExportConfigViewTest {
+
+    private static final RecipeInfo ALPHA = new RecipeInfo("org.example.Alpha", "Alpha", "Alpha recipe", Set.of());
+    private static final RecipeInfo BETA = new RecipeInfo("org.example.Beta", "Beta", "Beta recipe", Set.of());
+
+    private TuiController controllerWithSelectedRecipes() {
+        TuiController controller = new TuiController(List.of(ALPHA, BETA));
+        controller.toggleSelection(); // select ALPHA
+        controller.moveDown();
+        controller.toggleSelection(); // select BETA
+        controller.openConfirmRun();
+        return controller;
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.21"})
+    void rendersGradleSnippetByDefault() {
+        TuiController controller = controllerWithSelectedRecipes();
+
+        Element element = ExportConfigView.render(controller);
+
+        assertThat(element).isNotNull();
+        assertThat(controller.exportFormat()).isEqualTo(TuiController.ExportFormat.GRADLE);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.22"})
+    void setFormatToMavenProducesMavenSnippet() {
+        TuiController controller = controllerWithSelectedRecipes();
+
+        controller.setExportFormat(TuiController.ExportFormat.MAVEN);
+
+        assertThat(controller.exportFormat()).isEqualTo(TuiController.ExportFormat.MAVEN);
+        Element element = ExportConfigView.render(controller);
+        assertThat(element).isNotNull();
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.23"})
+    void toggleExportModeProducesFullSnippet() {
+        TuiController controller = controllerWithSelectedRecipes();
+
+        controller.toggleExportMode();
+
+        assertThat(controller.exportMode()).isEqualTo(ConfigExportService.ExportMode.FULL);
+        Element element = ExportConfigView.render(controller);
+        assertThat(element).isNotNull();
+    }
+}

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -447,6 +447,40 @@ requirements:
     categories: [interaction-capability]
     revision: 0.1.0
 
+  - id: TUI_0001.21
+    title: TUI — Export Config Overlay
+    significance: shall
+    description: >-
+      The TUI shall provide an export overlay accessible from the confirm-run
+      screen (x key) that displays the current run configuration as a Maven or
+      Gradle plugin snippet using the core ConfigExportService
+    references:
+      requirement_ids: ["TUI_0001", "CORE_0009"]
+    categories: [compatibility]
+    revision: 0.1.0
+
+  - id: TUI_0001.22
+    title: TUI — Export Format Toggle
+    significance: shall
+    description: >-
+      The export overlay shall support toggling between Gradle and Maven output
+      formats via the g and m keys
+    references:
+      requirement_ids: ["TUI_0001.21"]
+    categories: [compatibility]
+    revision: 0.1.0
+
+  - id: TUI_0001.23
+    title: TUI — Export Mode Toggle
+    significance: shall
+    description: >-
+      The export overlay shall support toggling between Minimal (plugin snippet
+      only) and Full (standalone build file) output modes via the Tab key
+    references:
+      requirement_ids: ["TUI_0001.21"]
+    categories: [compatibility]
+    revision: 0.1.0
+
   # CLI requirements — list/search/run
   - id: CLI_0001
     title: CLI Default Behaviour — Launch TUI

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -809,6 +809,36 @@ cases:
       THEN the description is rendered as formatted markdown
     revision: "0.1.0"
 
+  - id: SVC_TUI_0001.21
+    requirement_ids: ["TUI_0001.21"]
+    title: TUI export overlay opens from confirm-run screen
+    verification: automated-test
+    description: |
+      GIVEN recipes are selected and the confirm-run screen is shown
+      WHEN the user presses x
+      THEN the export overlay is shown with a Gradle or Maven snippet
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.22
+    requirement_ids: ["TUI_0001.22"]
+    title: TUI export format toggle switches between Gradle and Maven
+    verification: automated-test
+    description: |
+      GIVEN the export overlay is open
+      WHEN the user presses g or m
+      THEN the snippet format switches to Gradle or Maven respectively
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0001.23
+    requirement_ids: ["TUI_0001.23"]
+    title: TUI export mode toggle switches between Minimal and Full
+    verification: automated-test
+    description: |
+      GIVEN the export overlay is open
+      WHEN the user presses Tab
+      THEN the output mode cycles between Minimal and Full
+    revision: "0.1.0"
+
   - id: SVC_CLI_0001
     requirement_ids: ["CLI_0001"]
     title: No-args invocation delegates to TUI subcommand

--- a/openspec/changes/archive/2026-05-19-tui-export-config-9/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-tui-export-config-9/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/archive/2026-05-19-tui-export-config-9/design.md
+++ b/openspec/changes/archive/2026-05-19-tui-export-config-9/design.md
@@ -1,0 +1,39 @@
+## Context
+
+`ConfigExportService` in `atunko-core` already provides `exportToGradle(RunConfig, ExportMode)` and `exportToMaven(RunConfig, ExportMode)` with MINIMAL and FULL modes. The Web UI surfaces this via a modal dialog. The TUI has no equivalent; the `ConfirmRunView` is the natural trigger point because `RunConfig` is fully assembled there.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `ExportConfigView` — a full-screen TUI overlay showing the exported snippet
+- Wire `e` on `ConfirmRunView` to open the overlay
+- Support format toggle (Gradle/Maven) and mode toggle (Minimal/Full) inside the overlay
+- Update help text in `ConfirmRunView` to document the new keybinding
+
+**Non-Goals:**
+- Writing the snippet to a file (clipboard/file export is out of scope for this change)
+- Exporting from `ExecutionResultsView` (confirm-run is the right moment; results are after execution)
+- Any changes to `ConfigExportService` or `RunConfig`
+
+## Decisions
+
+**D1 — Full-screen overlay, not a floating popup**
+TamboUI does not have a built-in modal dialog primitive. Existing overlays (`HelpOverlay`) are rendered inline as a `row(spacer(), content, spacer())`. For export we need a scrollable text area, so a full-screen approach (like `FileDiffView`) is cleaner. The overlay replaces the center content of `ConfirmRunView` when active, controlled by a flag on `TuiController`.
+
+**D2 — State on `TuiController`, not local to the view**
+TUI views are stateless renderers; all mutable state lives on `TuiController`. Two new fields: `exportFormat` (GRADLE/MAVEN enum) and `exportMode` (MINIMAL/FULL) are added. This is consistent with how `selectedFileIndex`, `showHelp`, etc. are managed.
+
+**D3 — Key bindings inside the overlay**
+- `g` → Gradle, `m` → Maven (format toggle)
+- `Tab` → toggles Minimal/Full mode
+- `Esc` → close overlay (return to confirm-run)
+
+These are unambiguous and consistent with the Web UI's Gradle/Maven concepts.
+
+**D4 — `markupTextArea` for display**
+`FileDiffView` uses `markupTextArea` for scrollable read-only content. The same widget is appropriate here for the snippet. No syntax highlighting needed; plain text is sufficient.
+
+## Risks / Trade-offs
+
+- [TamboUI snapshot instability] `markupTextArea` API may shift between snapshots → Mitigation: follow `FileDiffView` pattern exactly; pin TamboUI version in `gradle/libs.versions.toml`
+- [Long snippets] FULL mode generates ~20-line files; `markupTextArea` handles this natively with scrollbar → no special handling needed

--- a/openspec/changes/archive/2026-05-19-tui-export-config-9/proposal.md
+++ b/openspec/changes/archive/2026-05-19-tui-export-config-9/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Users can already export run configurations as Maven/Gradle plugin snippets from the Web UI and CLI, but the TUI has no export path — closing that gap means TUI-only users can copy a ready-to-paste build-file snippet without switching tools.
+
+## What Changes
+
+- Add a **TUI export overlay** that displays a Maven or Gradle snippet for the current run configuration, with a format toggle (Gradle/Maven) and a mode toggle (Minimal/Full).
+- Wire an `e` keybinding on the **ConfirmRunView** (pre-run confirmation screen) to open the overlay — the `RunConfig` is fully assembled there.
+- The overlay reads from `ConfigExportService` (CORE_0009) already in `atunko-core`; no new core logic is required.
+
+## Capabilities
+
+### New Capabilities
+
+- `tui-config-export`: Export the current run configuration to a Maven or Gradle plugin snippet from within the TUI, via a full-screen overlay launched from the confirm-run screen.
+
+### Modified Capabilities
+
+_(none — new sub-requirements under TUI_0001 cover the confirm-run keymap extension)_
+
+## Impact
+
+- **atunko-tui**: new `ExportConfigView.java`; minor changes to `ConfirmRunView.java` (key handler + help text)
+- **atunko-core**: no changes — `ConfigExportService` and `RunConfig` are already sufficient
+- **Dependencies**: no new dependencies
+- **reqstool**: new TUI sub-requirements under `TUI_0001` referencing `CORE_0009`

--- a/openspec/changes/archive/2026-05-19-tui-export-config-9/specs/tui-config-export/spec.md
+++ b/openspec/changes/archive/2026-05-19-tui-export-config-9/specs/tui-config-export/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: TUI_0001.21
+The system SHALL implement TUI_0001.21.
+
+#### Scenario: SVC_TUI_0001.21
+- **WHEN** the user presses `x` on the confirm-run screen
+- **THEN** the system SHALL pass SVC_TUI_0001.21.
+
+### Requirement: TUI_0001.22
+The system SHALL implement TUI_0001.22.
+
+#### Scenario: SVC_TUI_0001.22
+- **WHEN** the export overlay is open and the user presses `g` or `m`
+- **THEN** the system SHALL pass SVC_TUI_0001.22.
+
+### Requirement: TUI_0001.23
+The system SHALL implement TUI_0001.23.
+
+#### Scenario: SVC_TUI_0001.23
+- **WHEN** the export overlay is open and the user presses `Tab`
+- **THEN** the system SHALL pass SVC_TUI_0001.23.

--- a/openspec/changes/archive/2026-05-19-tui-export-config-9/tasks.md
+++ b/openspec/changes/archive/2026-05-19-tui-export-config-9/tasks.md
@@ -1,0 +1,48 @@
+## 1. reqstool — Add Requirements and SVCs
+
+- [x] 1.1 Add TUI_0001.21 to `docs/reqstool/requirements.yml` — export overlay accessible from confirm-run (`x` key)
+- [x] 1.2 Add TUI_0001.22 to `docs/reqstool/requirements.yml` — format toggle (Gradle/Maven) inside overlay
+- [x] 1.3 Add TUI_0001.23 to `docs/reqstool/requirements.yml` — mode toggle (Minimal/Full) inside overlay
+- [x] 1.4 Add SVC_TUI_0001.21 to `docs/reqstool/software_verification_cases.yml` (covers TUI_0001.21)
+- [x] 1.5 Add SVC_TUI_0001.22 to `docs/reqstool/software_verification_cases.yml` (covers TUI_0001.22)
+- [x] 1.6 Add SVC_TUI_0001.23 to `docs/reqstool/software_verification_cases.yml` (covers TUI_0001.23)
+
+## 2. TuiController — Export State
+
+- [x] 2.1 Add `ExportFormat` enum (GRADLE, MAVEN) to `TuiController`
+- [x] 2.2 Add `exportFormat` field (default GRADLE) and getter/setter to `TuiController`
+- [x] 2.3 Add `exportMode` field (default MINIMAL, type `ConfigExportService.ExportMode`) and getter/setter to `TuiController`
+- [x] 2.4 Add `showExport` boolean field and getter/setter to `TuiController`
+
+## 3. Tests — TuiController Export State
+
+- [x] 3.1 Unit test: default export state values (format=GRADLE, mode=MINIMAL, showExport=false)
+- [x] 3.2 Unit test: toggling `exportFormat` cycles GRADLE↔MAVEN
+- [x] 3.3 Unit test: toggling `exportMode` cycles MINIMAL↔FULL
+
+## 4. ExportConfigView — New View
+
+- [x] 4.1 Create `atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExportConfigView.java`
+- [x] 4.2 Render current snippet via `ConfigExportService` using `controller.exportFormat()` and `controller.exportMode()`
+- [x] 4.3 Display snippet in `markupTextArea` with scrollbar (follow `FileDiffView` pattern)
+- [x] 4.4 Header row: title + current format + mode indicators
+- [x] 4.5 Footer status bar: `g:Gradle m:Maven Tab:Minimal/Full Esc:close`
+- [x] 4.6 Key handler: `g` → GRADLE, `m` → MAVEN, `Tab` → toggle mode, `Esc` → `showExport=false`
+- [x] 4.7 Annotate with `@Requirements({"atunko:TUI_0001.21", "atunko:TUI_0001.22", "atunko:TUI_0001.23"})`
+
+## 5. ConfirmRunView — Wire Export
+
+- [x] 5.1 Detect `controller.isShowExport()` and render `ExportConfigView.render(controller)` in place of normal content
+- [x] 5.2 Add `x` key handler in `ConfirmRunView`: sets `showExport=true` (note: `e` was already bound to expand)
+- [x] 5.3 Update footer status bar to include `x:export`
+
+## 6. Tests — ExportConfigView / Integration
+
+- [x] 6.1 Unit test: `ExportConfigView` renders Gradle snippet for a `RunConfig` with known recipes (covers SVC_TUI_0001.21)
+- [x] 6.2 Unit test: format toggle updates rendered snippet to Maven (covers SVC_TUI_0001.22)
+- [x] 6.3 Unit test: mode toggle switches between MINIMAL and FULL snippets (covers SVC_TUI_0001.23)
+
+## 7. Build & Quality
+
+- [x] 7.1 Run `./gradlew spotlessApply` — fix any formatting issues
+- [x] 7.2 Run `./gradlew build` — confirm clean build, all tests pass

--- a/openspec/specs/tui-config-export/spec.md
+++ b/openspec/specs/tui-config-export/spec.md
@@ -1,0 +1,23 @@
+## Purpose
+
+Provide an export overlay in the TUI that renders the current run configuration as a Maven or Gradle plugin snippet, accessible from the confirm-run screen.
+
+## Requirements
+
+### Requirement: TUI_0001.21
+The system SHALL implement TUI_0001.21.
+
+#### Scenario: SVC_TUI_0001.21
+The system SHALL pass SVC_TUI_0001.21.
+
+### Requirement: TUI_0001.22
+The system SHALL implement TUI_0001.22.
+
+#### Scenario: SVC_TUI_0001.22
+The system SHALL pass SVC_TUI_0001.22.
+
+### Requirement: TUI_0001.23
+The system SHALL implement TUI_0001.23.
+
+#### Scenario: SVC_TUI_0001.23
+The system SHALL pass SVC_TUI_0001.23.


### PR DESCRIPTION
## Summary

- Adds `ExportConfigView` — a full-screen overlay accessible from the confirm-run screen via `x`, displaying the current run configuration as a Maven or Gradle plugin snippet
- Wires `ExportFormat` (GRADLE/MAVEN) and `ExportMode` (MINIMAL/FULL) state into `TuiController`; keybindings `g`/`m` toggle format, `Tab` toggles mode, `Esc` closes
- Delegates to the existing `ConfigExportService` in `atunko-core` — no new core logic

## Requirements

Closes #9

New reqstool requirements: `TUI_0001.21`, `TUI_0001.22`, `TUI_0001.23` (SVCs: `SVC_TUI_0001.21–23`)

## Test plan

- [x] `TuiControllerTest`: default export state, format toggle, mode toggle
- [x] `ExportConfigViewTest`: Gradle render, Maven format switch, Full mode switch
- [x] `./gradlew build` passes clean