### PR TITLE
feat(tui): add mouse support — scroll and click events in all TUI views (#15)

### DIFF
--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
@@ -55,17 +55,19 @@ public class AtunkoTui extends ToolkitApp {
         };
     }
 
+    @Requirements({"atunko:TUI_0001.27"})
     @Override
     protected TuiConfig configure() {
         if (logFile != null) {
             return TuiConfig.builder()
+                    .mouseCapture(true)
                     .errorHandler((error, context) -> {
                         Logger.getLogger("io.github.atunkodev").log(Level.SEVERE, "Render error", error.cause());
                         return ErrorAction.QUIT_IMMEDIATELY;
                     })
                     .build();
         }
-        return TuiConfig.defaults();
+        return TuiConfig.builder().mouseCapture(true).build();
     }
 
     @Override

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/AtunkoTui.java
@@ -55,8 +55,8 @@ public class AtunkoTui extends ToolkitApp {
         };
     }
 
-    @Requirements({"atunko:TUI_0001.27"})
     @Override
+    @Requirements({"atunko:TUI_0001.27"})
     protected TuiConfig configure() {
         if (logFile != null) {
             return TuiConfig.builder()

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -1035,12 +1035,14 @@ public class TuiController {
         return loadConfigHighlightIndex;
     }
 
+    @Requirements({"atunko:TUI_0001.27"})
     public void moveLoadConfigDown() {
         if (!configFiles.isEmpty()) {
             loadConfigHighlightIndex = Math.min(loadConfigHighlightIndex + 1, configFiles.size() - 1);
         }
     }
 
+    @Requirements({"atunko:TUI_0001.27"})
     public void moveLoadConfigUp() {
         loadConfigHighlightIndex = Math.max(0, loadConfigHighlightIndex - 1);
     }
@@ -1276,14 +1278,23 @@ public class TuiController {
 
     @Requirements({"atunko:TUI_0001.27"})
     public void setBrowserHighlightIndex(int idx) {
-        browserState.setHighlightedIndex(idx);
+        List<DisplayRow> rows = displayRows();
+        if (rows.isEmpty()) {
+            return;
+        }
+        browserState.setHighlightedIndex(Math.max(0, Math.min(idx, rows.size() - 1)));
     }
 
     @Requirements({"atunko:TUI_0001.27"})
     public void setRunHighlightIndex(int idx) {
-        if (runState != null) {
-            runState.setHighlightedIndex(idx);
+        if (runState == null) {
+            return;
         }
+        List<DisplayRow> rows = runDisplayRows();
+        if (rows.isEmpty()) {
+            return;
+        }
+        runState.setHighlightedIndex(Math.max(0, Math.min(idx, rows.size() - 1)));
     }
 
     private List<RecipeInfo> filterRecipes() {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/TuiController.java
@@ -1045,6 +1045,13 @@ public class TuiController {
         loadConfigHighlightIndex = Math.max(0, loadConfigHighlightIndex - 1);
     }
 
+    @Requirements({"atunko:TUI_0001.27"})
+    public void setLoadConfigHighlightIndex(int idx) {
+        if (!configFiles.isEmpty()) {
+            loadConfigHighlightIndex = Math.max(0, Math.min(idx, configFiles.size() - 1));
+        }
+    }
+
     public void confirmLoadConfig() throws IOException {
         if (configFiles.isEmpty()) {
             return;
@@ -1256,6 +1263,27 @@ public class TuiController {
         Files.createDirectories(dir);
         saveRunConfig(dir.resolve(saveConfigName + ".yml"));
         exitSaveConfigMode();
+    }
+
+    @Requirements({"atunko:TUI_0001.27"})
+    public int mouseRowToIndex(int mouseY, int headerRows, int rowCount) {
+        int idx = mouseY - headerRows;
+        if (idx < 0 || idx >= rowCount) {
+            return -1;
+        }
+        return idx;
+    }
+
+    @Requirements({"atunko:TUI_0001.27"})
+    public void setBrowserHighlightIndex(int idx) {
+        browserState.setHighlightedIndex(idx);
+    }
+
+    @Requirements({"atunko:TUI_0001.27"})
+    public void setRunHighlightIndex(int idx) {
+        if (runState != null) {
+            runState.setHighlightedIndex(idx);
+        }
     }
 
     private List<RecipeInfo> filterRecipes() {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
@@ -13,6 +13,8 @@ import static dev.tamboui.toolkit.Toolkit.textInput;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.MouseEvent;
+import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.input.TextInputState;
 import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.core.recipe.SortOrder;
@@ -70,18 +72,18 @@ public final class BrowserView {
                 .onMouseEvent(event -> handleMouseEvent(controller, event));
     }
 
-    private static EventResult handleMouseEvent(TuiController controller, dev.tamboui.tui.event.MouseEvent event) {
+    private static EventResult handleMouseEvent(TuiController controller, MouseEvent event) {
         if (controller.isShowHelp()
                 || controller.isSaveConfigMode()
                 || controller.isSearchMode()
                 || controller.isShowOptions()) {
             return EventResult.UNHANDLED;
         }
-        if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+        if (event.kind() == MouseEventKind.SCROLL_UP) {
             controller.moveUp();
             return EventResult.HANDLED;
         }
-        if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+        if (event.kind() == MouseEventKind.SCROLL_DOWN) {
             controller.moveDown();
             return EventResult.HANDLED;
         }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/BrowserView.java
@@ -66,7 +66,37 @@ public final class BrowserView {
                 .id("browser")
                 .addClass("app")
                 .focusable()
-                .onKeyEvent(event -> handleKeyEvent(controller, app, event));
+                .onKeyEvent(event -> handleKeyEvent(controller, app, event))
+                .onMouseEvent(event -> handleMouseEvent(controller, event));
+    }
+
+    private static EventResult handleMouseEvent(TuiController controller, dev.tamboui.tui.event.MouseEvent event) {
+        if (controller.isShowHelp()
+                || controller.isSaveConfigMode()
+                || controller.isSearchMode()
+                || controller.isShowOptions()) {
+            return EventResult.UNHANDLED;
+        }
+        if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+            controller.moveUp();
+            return EventResult.HANDLED;
+        }
+        if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+            controller.moveDown();
+            return EventResult.HANDLED;
+        }
+        if (event.isPress()) {
+            int idx = controller.mouseRowToIndex(
+                    event.y(), 3, controller.displayRows().size());
+            if (idx >= 0) {
+                controller.setBrowserHighlightIndex(idx);
+                if (event.isRightButton()) {
+                    controller.toggleSelection();
+                }
+                return EventResult.HANDLED;
+            }
+        }
+        return EventResult.UNHANDLED;
     }
 
     private static EventResult handleKeyEvent(

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
@@ -67,7 +67,38 @@ public final class ConfirmRunView {
                         .constraint(Constraint.fill()))
                 .id("confirm-run")
                 .focusable()
-                .onKeyEvent(event -> handleKeyEvent(controller, hasRecipes, event));
+                .onKeyEvent(event -> handleKeyEvent(controller, hasRecipes, event))
+                .onMouseEvent(event -> handleMouseEvent(controller, hasRecipes, event));
+    }
+
+    private static dev.tamboui.toolkit.event.EventResult handleMouseEvent(
+            TuiController controller, boolean hasRecipes, dev.tamboui.tui.event.MouseEvent event) {
+        if (controller.isShowHelp() || controller.isShowOptions() || controller.isShowExport()) {
+            return dev.tamboui.toolkit.event.EventResult.UNHANDLED;
+        }
+        if (!hasRecipes) {
+            return dev.tamboui.toolkit.event.EventResult.UNHANDLED;
+        }
+        if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+            controller.moveRunHighlightUp();
+            return dev.tamboui.toolkit.event.EventResult.HANDLED;
+        }
+        if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+            controller.moveRunHighlightDown();
+            return dev.tamboui.toolkit.event.EventResult.HANDLED;
+        }
+        if (event.isPress()) {
+            int idx = controller.mouseRowToIndex(
+                    event.y(), 1, controller.runDisplayRows().size());
+            if (idx >= 0) {
+                controller.setRunHighlightIndex(idx);
+                if (event.isRightButton()) {
+                    controller.toggleRunRecipe();
+                }
+                return dev.tamboui.toolkit.event.EventResult.HANDLED;
+            }
+        }
+        return dev.tamboui.toolkit.event.EventResult.UNHANDLED;
     }
 
     @Requirements({"atunko:TUI_0002.2"})

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ConfirmRunView.java
@@ -9,6 +9,8 @@ import static dev.tamboui.toolkit.Toolkit.text;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.MouseEvent;
+import dev.tamboui.tui.event.MouseEventKind;
 import io.github.atunkodev.core.project.ProjectEntry;
 import io.github.atunkodev.tui.TuiController;
 import io.github.atunkodev.tui.TuiController.DisplayRow;
@@ -71,21 +73,20 @@ public final class ConfirmRunView {
                 .onMouseEvent(event -> handleMouseEvent(controller, hasRecipes, event));
     }
 
-    private static dev.tamboui.toolkit.event.EventResult handleMouseEvent(
-            TuiController controller, boolean hasRecipes, dev.tamboui.tui.event.MouseEvent event) {
+    private static EventResult handleMouseEvent(TuiController controller, boolean hasRecipes, MouseEvent event) {
         if (controller.isShowHelp() || controller.isShowOptions() || controller.isShowExport()) {
-            return dev.tamboui.toolkit.event.EventResult.UNHANDLED;
+            return EventResult.UNHANDLED;
         }
         if (!hasRecipes) {
-            return dev.tamboui.toolkit.event.EventResult.UNHANDLED;
+            return EventResult.UNHANDLED;
         }
-        if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+        if (event.kind() == MouseEventKind.SCROLL_UP) {
             controller.moveRunHighlightUp();
-            return dev.tamboui.toolkit.event.EventResult.HANDLED;
+            return EventResult.HANDLED;
         }
-        if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+        if (event.kind() == MouseEventKind.SCROLL_DOWN) {
             controller.moveRunHighlightDown();
-            return dev.tamboui.toolkit.event.EventResult.HANDLED;
+            return EventResult.HANDLED;
         }
         if (event.isPress()) {
             int idx = controller.mouseRowToIndex(
@@ -95,10 +96,10 @@ public final class ConfirmRunView {
                 if (event.isRightButton()) {
                     controller.toggleRunRecipe();
                 }
-                return dev.tamboui.toolkit.event.EventResult.HANDLED;
+                return EventResult.HANDLED;
             }
         }
-        return dev.tamboui.toolkit.event.EventResult.UNHANDLED;
+        return EventResult.UNHANDLED;
     }
 
     @Requirements({"atunko:TUI_0002.2"})

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
@@ -106,7 +106,18 @@ public final class ExecutionResultsView {
                         .constraint(Constraint.fill()))
                 .id("execution-results")
                 .focusable()
-                .onKeyEvent(event -> handleKeyEvent(controller, event));
+                .onKeyEvent(event -> handleKeyEvent(controller, event))
+                .onMouseEvent(event -> {
+                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+                        controller.moveFileUp();
+                        return EventResult.HANDLED;
+                    }
+                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+                        controller.moveFileDown();
+                        return EventResult.HANDLED;
+                    }
+                    return EventResult.UNHANDLED;
+                });
     }
 
     private static EventResult handleKeyEvent(TuiController controller, dev.tamboui.tui.event.KeyEvent event) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
@@ -10,6 +10,7 @@ import static dev.tamboui.toolkit.Toolkit.text;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.MouseEventKind;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
 import io.github.atunkodev.core.engine.ProjectExecutionResult;
@@ -108,11 +109,11 @@ public final class ExecutionResultsView {
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, event))
                 .onMouseEvent(event -> {
-                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+                    if (event.kind() == MouseEventKind.SCROLL_UP) {
                         controller.moveFileUp();
                         return EventResult.HANDLED;
                     }
-                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+                    if (event.kind() == MouseEventKind.SCROLL_DOWN) {
                         controller.moveFileDown();
                         return EventResult.HANDLED;
                     }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/ExecutionResultsView.java
@@ -10,6 +10,7 @@ import static dev.tamboui.toolkit.Toolkit.text;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.MouseEvent;
 import dev.tamboui.tui.event.MouseEventKind;
 import io.github.atunkodev.core.engine.ExecutionResult;
 import io.github.atunkodev.core.engine.FileChange;
@@ -108,17 +109,19 @@ public final class ExecutionResultsView {
                 .id("execution-results")
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, event))
-                .onMouseEvent(event -> {
-                    if (event.kind() == MouseEventKind.SCROLL_UP) {
-                        controller.moveFileUp();
-                        return EventResult.HANDLED;
-                    }
-                    if (event.kind() == MouseEventKind.SCROLL_DOWN) {
-                        controller.moveFileDown();
-                        return EventResult.HANDLED;
-                    }
-                    return EventResult.UNHANDLED;
-                });
+                .onMouseEvent(event -> handleMouseEvent(controller, event));
+    }
+
+    private static EventResult handleMouseEvent(TuiController controller, MouseEvent event) {
+        if (event.kind() == MouseEventKind.SCROLL_UP) {
+            controller.moveFileUp();
+            return EventResult.HANDLED;
+        }
+        if (event.kind() == MouseEventKind.SCROLL_DOWN) {
+            controller.moveFileDown();
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
     }
 
     private static EventResult handleKeyEvent(TuiController controller, dev.tamboui.tui.event.KeyEvent event) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
@@ -51,13 +51,32 @@ public final class LoadConfigView {
 
         Element statusBar = text(" j/k:navigate  Enter:load  Esc/q:back").addClass("status-bar");
 
+        final List<Path> finalConfigFiles = configFiles;
         return column(dock().top(header, Constraint.length(1))
                         .center(centerContent)
                         .bottom(statusBar, Constraint.length(1))
                         .constraint(Constraint.fill()))
                 .id("load-config")
                 .focusable()
-                .onKeyEvent(event -> handleKeyEvent(controller, event));
+                .onKeyEvent(event -> handleKeyEvent(controller, event))
+                .onMouseEvent(event -> {
+                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+                        controller.moveLoadConfigUp();
+                        return EventResult.HANDLED;
+                    }
+                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+                        controller.moveLoadConfigDown();
+                        return EventResult.HANDLED;
+                    }
+                    if (event.isPress() && event.isLeftButton()) {
+                        int idx = controller.mouseRowToIndex(event.y(), 1, finalConfigFiles.size());
+                        if (idx >= 0) {
+                            controller.setLoadConfigHighlightIndex(idx);
+                            return EventResult.HANDLED;
+                        }
+                    }
+                    return EventResult.UNHANDLED;
+                });
     }
 
     private static EventResult handleKeyEvent(TuiController controller, dev.tamboui.tui.event.KeyEvent event) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
@@ -9,6 +9,7 @@ import static dev.tamboui.toolkit.Toolkit.text;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.MouseEvent;
 import dev.tamboui.tui.event.MouseEventKind;
 import io.github.atunkodev.tui.TuiController;
 import io.github.reqstool.annotations.Requirements;
@@ -59,25 +60,27 @@ public final class LoadConfigView {
                 .id("load-config")
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, event))
-                .onMouseEvent(event -> {
-                    if (event.kind() == MouseEventKind.SCROLL_UP) {
-                        controller.moveLoadConfigUp();
-                        return EventResult.HANDLED;
-                    }
-                    if (event.kind() == MouseEventKind.SCROLL_DOWN) {
-                        controller.moveLoadConfigDown();
-                        return EventResult.HANDLED;
-                    }
-                    if (event.isPress() && event.isLeftButton()) {
-                        int idx = controller.mouseRowToIndex(
-                                event.y(), 1, controller.configFiles().size());
-                        if (idx >= 0) {
-                            controller.setLoadConfigHighlightIndex(idx);
-                            return EventResult.HANDLED;
-                        }
-                    }
-                    return EventResult.UNHANDLED;
-                });
+                .onMouseEvent(event -> handleMouseEvent(controller, event));
+    }
+
+    private static EventResult handleMouseEvent(TuiController controller, MouseEvent event) {
+        if (event.kind() == MouseEventKind.SCROLL_UP) {
+            controller.moveLoadConfigUp();
+            return EventResult.HANDLED;
+        }
+        if (event.kind() == MouseEventKind.SCROLL_DOWN) {
+            controller.moveLoadConfigDown();
+            return EventResult.HANDLED;
+        }
+        if (event.isPress() && event.isLeftButton()) {
+            int idx = controller.mouseRowToIndex(
+                    event.y(), 1, controller.configFiles().size());
+            if (idx >= 0) {
+                controller.setLoadConfigHighlightIndex(idx);
+                return EventResult.HANDLED;
+            }
+        }
+        return EventResult.UNHANDLED;
     }
 
     private static EventResult handleKeyEvent(TuiController controller, dev.tamboui.tui.event.KeyEvent event) {

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/LoadConfigView.java
@@ -9,6 +9,7 @@ import static dev.tamboui.toolkit.Toolkit.text;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.MouseEventKind;
 import io.github.atunkodev.tui.TuiController;
 import io.github.reqstool.annotations.Requirements;
 import java.nio.file.Path;
@@ -51,7 +52,6 @@ public final class LoadConfigView {
 
         Element statusBar = text(" j/k:navigate  Enter:load  Esc/q:back").addClass("status-bar");
 
-        final List<Path> finalConfigFiles = configFiles;
         return column(dock().top(header, Constraint.length(1))
                         .center(centerContent)
                         .bottom(statusBar, Constraint.length(1))
@@ -60,16 +60,17 @@ public final class LoadConfigView {
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, event))
                 .onMouseEvent(event -> {
-                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+                    if (event.kind() == MouseEventKind.SCROLL_UP) {
                         controller.moveLoadConfigUp();
                         return EventResult.HANDLED;
                     }
-                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+                    if (event.kind() == MouseEventKind.SCROLL_DOWN) {
                         controller.moveLoadConfigDown();
                         return EventResult.HANDLED;
                     }
                     if (event.isPress() && event.isLeftButton()) {
-                        int idx = controller.mouseRowToIndex(event.y(), 1, finalConfigFiles.size());
+                        int idx = controller.mouseRowToIndex(
+                                event.y(), 1, controller.configFiles().size());
                         if (idx >= 0) {
                             controller.setLoadConfigHighlightIndex(idx);
                             return EventResult.HANDLED;

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeOptionsView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeOptionsView.java
@@ -12,6 +12,7 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
 import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.MouseEventKind;
 import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.core.recipe.RecipeOptionInfo;
 import io.github.atunkodev.tui.TuiController;
@@ -62,11 +63,14 @@ public final class RecipeOptionsView {
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, options, event))
                 .onMouseEvent(event -> {
-                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+                    if (controller.isOptionsEditing()) {
+                        return EventResult.UNHANDLED;
+                    }
+                    if (event.kind() == MouseEventKind.SCROLL_UP) {
                         controller.moveOptionHighlightUp(options.size());
                         return EventResult.HANDLED;
                     }
-                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+                    if (event.kind() == MouseEventKind.SCROLL_DOWN) {
                         controller.moveOptionHighlightDown(options.size());
                         return EventResult.HANDLED;
                     }

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeOptionsView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeOptionsView.java
@@ -12,6 +12,7 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
 import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.MouseEvent;
 import dev.tamboui.tui.event.MouseEventKind;
 import io.github.atunkodev.core.recipe.RecipeInfo;
 import io.github.atunkodev.core.recipe.RecipeOptionInfo;
@@ -62,20 +63,7 @@ public final class RecipeOptionsView {
                 .id("recipe-options")
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, options, event))
-                .onMouseEvent(event -> {
-                    if (controller.isOptionsEditing()) {
-                        return EventResult.UNHANDLED;
-                    }
-                    if (event.kind() == MouseEventKind.SCROLL_UP) {
-                        controller.moveOptionHighlightUp(options.size());
-                        return EventResult.HANDLED;
-                    }
-                    if (event.kind() == MouseEventKind.SCROLL_DOWN) {
-                        controller.moveOptionHighlightDown(options.size());
-                        return EventResult.HANDLED;
-                    }
-                    return EventResult.UNHANDLED;
-                });
+                .onMouseEvent(event -> handleMouseEvent(controller, options, event));
     }
 
     private static Element buildOptionsList(
@@ -119,6 +107,22 @@ public final class RecipeOptionsView {
             rows[i] = column(row(nameCell, typeCell, spacer(), valCell), descRow);
         }
         return column(rows);
+    }
+
+    private static EventResult handleMouseEvent(
+            TuiController controller, List<RecipeOptionInfo> options, MouseEvent event) {
+        if (controller.isOptionsEditing()) {
+            return EventResult.UNHANDLED;
+        }
+        if (event.kind() == MouseEventKind.SCROLL_UP) {
+            controller.moveOptionHighlightUp(options.size());
+            return EventResult.HANDLED;
+        }
+        if (event.kind() == MouseEventKind.SCROLL_DOWN) {
+            controller.moveOptionHighlightDown(options.size());
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
     }
 
     private static EventResult handleKeyEvent(

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeOptionsView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/RecipeOptionsView.java
@@ -60,7 +60,18 @@ public final class RecipeOptionsView {
                         .constraint(Constraint.fill()))
                 .id("recipe-options")
                 .focusable()
-                .onKeyEvent(event -> handleKeyEvent(controller, options, event));
+                .onKeyEvent(event -> handleKeyEvent(controller, options, event))
+                .onMouseEvent(event -> {
+                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+                        controller.moveOptionHighlightUp(options.size());
+                        return EventResult.HANDLED;
+                    }
+                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+                        controller.moveOptionHighlightDown(options.size());
+                        return EventResult.HANDLED;
+                    }
+                    return EventResult.UNHANDLED;
+                });
     }
 
     private static Element buildOptionsList(

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
@@ -12,6 +12,7 @@ import static dev.tamboui.toolkit.Toolkit.textInput;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.input.TextInputState;
 import io.github.atunkodev.tui.TuiController;
 import io.github.reqstool.annotations.Requirements;
@@ -85,15 +86,15 @@ public final class TagBrowserView {
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, tags, event))
                 .onMouseEvent(event -> {
-                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+                    if (event.kind() == MouseEventKind.SCROLL_UP) {
                         tagIndex = Math.max(tagIndex - 1, 0);
-                        return dev.tamboui.toolkit.event.EventResult.HANDLED;
+                        return EventResult.HANDLED;
                     }
-                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+                    if (event.kind() == MouseEventKind.SCROLL_DOWN) {
                         tagIndex = Math.min(tagIndex + 1, Math.max(tags.size() - 1, 0));
-                        return dev.tamboui.toolkit.event.EventResult.HANDLED;
+                        return EventResult.HANDLED;
                     }
-                    return dev.tamboui.toolkit.event.EventResult.UNHANDLED;
+                    return EventResult.UNHANDLED;
                 });
     }
 

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
@@ -12,6 +12,7 @@ import static dev.tamboui.toolkit.Toolkit.textInput;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.MouseEvent;
 import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.input.TextInputState;
 import io.github.atunkodev.tui.TuiController;
@@ -85,17 +86,26 @@ public final class TagBrowserView {
                 .id("tag-browser")
                 .focusable()
                 .onKeyEvent(event -> handleKeyEvent(controller, tags, event))
-                .onMouseEvent(event -> {
-                    if (event.kind() == MouseEventKind.SCROLL_UP) {
-                        tagIndex = Math.max(tagIndex - 1, 0);
-                        return EventResult.HANDLED;
-                    }
-                    if (event.kind() == MouseEventKind.SCROLL_DOWN) {
-                        tagIndex = Math.min(tagIndex + 1, Math.max(tags.size() - 1, 0));
-                        return EventResult.HANDLED;
-                    }
-                    return EventResult.UNHANDLED;
-                });
+                .onMouseEvent(event -> handleMouseEvent(controller, tags, event));
+    }
+
+    private static EventResult handleMouseEvent(TuiController controller, List<String> tags, MouseEvent event) {
+        if (event.kind() == MouseEventKind.SCROLL_UP) {
+            tagIndex = Math.max(tagIndex - 1, 0);
+            return EventResult.HANDLED;
+        }
+        if (event.kind() == MouseEventKind.SCROLL_DOWN) {
+            tagIndex = Math.min(tagIndex + 1, Math.max(tags.size() - 1, 0));
+            return EventResult.HANDLED;
+        }
+        if (event.isPress() && event.isLeftButton()) {
+            int idx = controller.mouseRowToIndex(event.y(), 3, tags.size());
+            if (idx >= 0) {
+                tagIndex = idx;
+                return EventResult.HANDLED;
+            }
+        }
+        return EventResult.UNHANDLED;
     }
 
     private static EventResult handleKeyEvent(

--- a/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
+++ b/atunko-tui/src/main/java/io/github/atunkodev/tui/view/TagBrowserView.java
@@ -83,7 +83,18 @@ public final class TagBrowserView {
                         .constraint(Constraint.fill()))
                 .id("tag-browser")
                 .focusable()
-                .onKeyEvent(event -> handleKeyEvent(controller, tags, event));
+                .onKeyEvent(event -> handleKeyEvent(controller, tags, event))
+                .onMouseEvent(event -> {
+                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+                        tagIndex = Math.max(tagIndex - 1, 0);
+                        return dev.tamboui.toolkit.event.EventResult.HANDLED;
+                    }
+                    if (event.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_DOWN) {
+                        tagIndex = Math.min(tagIndex + 1, Math.max(tags.size() - 1, 0));
+                        return dev.tamboui.toolkit.event.EventResult.HANDLED;
+                    }
+                    return dev.tamboui.toolkit.event.EventResult.UNHANDLED;
+                });
     }
 
     private static EventResult handleKeyEvent(

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -1941,4 +1941,38 @@ class TuiControllerTest {
 
         assertThat(loaded.recipes().get(0).options()).containsEntry("targetVersion", "17");
     }
+
+    // --- Mouse row-to-index (TUI_0001.27) ---
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void mouseRowToIndexInRange() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.mouseRowToIndex(3, 1, 5)).isEqualTo(2);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void mouseRowToIndexBelowHeader() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.mouseRowToIndex(0, 2, 5)).isEqualTo(-1);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void mouseRowToIndexAboveList() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.mouseRowToIndex(1, 2, 5)).isEqualTo(-1);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void mouseRowToIndexAboveRowCount() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.mouseRowToIndex(10, 1, 5)).isEqualTo(-1);
+    }
 }

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/TuiControllerTest.java
@@ -1962,7 +1962,7 @@ class TuiControllerTest {
 
     @Test
     @SVCs({"atunko:SVC_TUI_0001.27"})
-    void mouseRowToIndexAboveList() {
+    void mouseRowToIndexInsideHeader() {
         TuiController controller = new TuiController(RECIPES);
 
         assertThat(controller.mouseRowToIndex(1, 2, 5)).isEqualTo(-1);
@@ -1974,5 +1974,38 @@ class TuiControllerTest {
         TuiController controller = new TuiController(RECIPES);
 
         assertThat(controller.mouseRowToIndex(10, 1, 5)).isEqualTo(-1);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void mouseRowToIndexAtFirstValidRow() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.mouseRowToIndex(2, 2, 5)).isEqualTo(0);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void mouseRowToIndexAtLastValidRow() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.mouseRowToIndex(5, 1, 5)).isEqualTo(4);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void mouseRowToIndexEmptyList() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.mouseRowToIndex(1, 1, 0)).isEqualTo(-1);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void mouseRowToIndexNoHeader() {
+        TuiController controller = new TuiController(RECIPES);
+
+        assertThat(controller.mouseRowToIndex(0, 0, 5)).isEqualTo(0);
+        assertThat(controller.mouseRowToIndex(4, 0, 5)).isEqualTo(4);
     }
 }

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/view/BrowserViewMouseTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/view/BrowserViewMouseTest.java
@@ -1,0 +1,103 @@
+package io.github.atunkodev.tui.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.MouseButton;
+import dev.tamboui.tui.event.MouseEvent;
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.atunkodev.tui.AtunkoTui;
+import io.github.atunkodev.tui.TuiController;
+import io.github.reqstool.annotations.SVCs;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+@SVCs({"atunko:SVC_TUI_0001.27"})
+class BrowserViewMouseTest {
+
+    private static final RecipeInfo ALPHA =
+            new RecipeInfo("org.test.Alpha", "Alpha Recipe", "First recipe", Set.of("java"));
+    private static final RecipeInfo BETA =
+            new RecipeInfo("org.test.Beta", "Beta Recipe", "Second recipe", Set.of("spring"));
+    private static final RecipeInfo GAMMA =
+            new RecipeInfo("org.test.Gamma", "Gamma Recipe", "Third recipe", Set.of("java"));
+
+    private static final List<RecipeInfo> RECIPES = List.of(ALPHA, BETA, GAMMA);
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void scrollUpMovesHighlightUp() {
+        TuiController controller = new TuiController(RECIPES);
+        controller.moveDown();
+        assertThat(controller.highlightedIndex()).isEqualTo(1);
+
+        AtunkoTui app = new AtunkoTui(controller);
+        Element el = BrowserView.render(controller, app);
+
+        EventResult result = el.handleMouseEvent(MouseEvent.scrollUp(0, 5));
+
+        assertThat(result).isEqualTo(EventResult.HANDLED);
+        assertThat(controller.highlightedIndex()).isEqualTo(0);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void scrollDownMovesHighlightDown() {
+        TuiController controller = new TuiController(RECIPES);
+
+        AtunkoTui app = new AtunkoTui(controller);
+        Element el = BrowserView.render(controller, app);
+
+        EventResult result = el.handleMouseEvent(MouseEvent.scrollDown(0, 5));
+
+        assertThat(result).isEqualTo(EventResult.HANDLED);
+        assertThat(controller.highlightedIndex()).isEqualTo(1);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void leftClickSetsHighlightByRow() {
+        TuiController controller = new TuiController(RECIPES);
+
+        AtunkoTui app = new AtunkoTui(controller);
+        Element el = BrowserView.render(controller, app);
+
+        // header is 3 rows; row y=4 → list index 1 (second recipe)
+        EventResult result = el.handleMouseEvent(MouseEvent.press(MouseButton.LEFT, 0, 4));
+
+        assertThat(result).isEqualTo(EventResult.HANDLED);
+        assertThat(controller.highlightedIndex()).isEqualTo(1);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void rightClickHighlightsAndTogglesSelection() {
+        TuiController controller = new TuiController(RECIPES);
+
+        AtunkoTui app = new AtunkoTui(controller);
+        Element el = BrowserView.render(controller, app);
+
+        // header is 3 rows; row y=3 → list index 0 (first recipe)
+        EventResult result = el.handleMouseEvent(MouseEvent.press(MouseButton.RIGHT, 0, 3));
+
+        assertThat(result).isEqualTo(EventResult.HANDLED);
+        assertThat(controller.highlightedIndex()).isEqualTo(0);
+        assertThat(controller.selectedRecipes()).contains("org.test.Alpha");
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void mouseIgnoredWhenShowHelp() {
+        TuiController controller = new TuiController(RECIPES);
+        controller.toggleHelp();
+
+        AtunkoTui app = new AtunkoTui(controller);
+        Element el = BrowserView.render(controller, app);
+
+        el.handleMouseEvent(MouseEvent.scrollDown(0, 5));
+
+        assertThat(controller.highlightedIndex()).isEqualTo(0);
+    }
+}

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/view/BrowserViewMouseTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/view/BrowserViewMouseTest.java
@@ -96,8 +96,39 @@ class BrowserViewMouseTest {
         AtunkoTui app = new AtunkoTui(controller);
         Element el = BrowserView.render(controller, app);
 
-        el.handleMouseEvent(MouseEvent.scrollDown(0, 5));
+        EventResult result = el.handleMouseEvent(MouseEvent.scrollDown(0, 5));
 
+        assertThat(result).isEqualTo(EventResult.UNHANDLED);
+        assertThat(controller.highlightedIndex()).isEqualTo(0);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void clickAboveHeaderIsIgnored() {
+        TuiController controller = new TuiController(RECIPES);
+
+        AtunkoTui app = new AtunkoTui(controller);
+        Element el = BrowserView.render(controller, app);
+
+        // header is 3 rows; y=2 is inside the header → no list row
+        EventResult result = el.handleMouseEvent(MouseEvent.press(MouseButton.LEFT, 0, 2));
+
+        assertThat(result).isEqualTo(EventResult.UNHANDLED);
+        assertThat(controller.highlightedIndex()).isEqualTo(0);
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0001.27"})
+    void clickBeyondLastRowIsIgnored() {
+        TuiController controller = new TuiController(RECIPES);
+
+        AtunkoTui app = new AtunkoTui(controller);
+        Element el = BrowserView.render(controller, app);
+
+        // 3 recipes, header=3 rows; last valid y=5; y=6 is beyond list
+        EventResult result = el.handleMouseEvent(MouseEvent.press(MouseButton.LEFT, 0, 6));
+
+        assertThat(result).isEqualTo(EventResult.UNHANDLED);
         assertThat(controller.highlightedIndex()).isEqualTo(0);
     }
 }

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -525,6 +525,16 @@ requirements:
     categories: [functional-suitability]
     revision: 0.1.0
 
+  - id: TUI_0001.27
+    title: TUI — Mouse Capture Enabled
+    significance: shall
+    description: >-
+      The TUI shall enable OS-level mouse capture so that scroll and click events are
+      delivered to view mouse-event handlers; both the default and logging variants of
+      TuiConfig must enable mouseCapture(true)
+    categories: [functional-suitability]
+    revision: 0.1.0
+
   # CLI requirements — list/search/run
   - id: CLI_0001
     title: CLI Default Behaviour — Launch TUI

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -874,6 +874,18 @@ cases:
       recipes with no configured options have a null options map
     revision: "0.1.0"
 
+  - id: SVC_TUI_0001.27
+    requirement_ids: ["TUI_0001.27"]
+    title: Mouse capture enabled — mouse events handled in TUI views
+    verification: automated-test
+    description: |
+      GIVEN the TUI is configured
+      WHEN TuiConfig is built in AtunkoTui.configure()
+      THEN mouseCapture(true) is set in both the default and logging-enabled variants;
+      WHEN a mouse scroll or click event arrives
+      THEN the view mouse-event handler processes it correctly
+    revision: "0.1.0"
+
   - id: SVC_CLI_0001
     requirement_ids: ["CLI_0001"]
     title: No-args invocation delegates to TUI subcommand

--- a/openspec/changes/tui-mouse-support-15/design.md
+++ b/openspec/changes/tui-mouse-support-15/design.md
@@ -1,0 +1,100 @@
+## Context
+
+TamboUI 0.2.0-SNAPSHOT provides a full mouse-event model:
+
+- `dev.tamboui.tui.event.MouseEvent` — fields: `x` (column), `y` (row), `kind`
+  (`MouseEventKind` enum), `button` (`LEFT`, `RIGHT`, `MIDDLE`, `NONE`), `modifiers`.
+- `dev.tamboui.tui.event.MouseEventKind` — values: `PRESS`, `RELEASE`, `DRAG`, `MOVE`,
+  `SCROLL_UP`, `SCROLL_DOWN`.
+- `dev.tamboui.toolkit.event.MouseEventHandler` — functional interface
+  `EventResult handle(MouseEvent e)`.
+- `StyledElement.onMouseEvent(MouseEventHandler)` — registers a handler on any element.
+- `TuiConfig.builder().mouseCapture(true).build()` — enables OS-level mouse capture in the
+  terminal backend.
+
+Currently `AtunkoTui.configure()` returns `TuiConfig.defaults()` (or a logging variant),
+neither of which enables mouse capture.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable mouse capture once in `AtunkoTui.configure()`.
+- Add `onMouseEvent()` handlers to the root focusable element of each view.
+- Support: scroll-to-navigate lists, left-click-to-highlight, right-click-to-toggle-select.
+- Keep all state mutations on `TuiController`; views remain stateless.
+- Tested: unit tests for new controller helpers; view mouse-handler unit tests for the
+  BrowserView list (scroll up/down, click-to-highlight, right-click-to-select).
+
+**Non-Goals:**
+- Drag-and-drop reordering.
+- Hover tooltips.
+- Pixel-precise hit detection (row-offset calculation is approximate).
+- Mouse support inside text-input widgets (TamboUI handles those internally).
+
+## Decisions
+
+### 1. Enable mouseCapture in configure()
+
+`AtunkoTui.configure()` currently has two branches (with/without logFile).  
+**Decision:** Both branches set `.mouseCapture(true)`.
+
+```java
+return TuiConfig.builder()
+    .mouseCapture(true)
+    .errorHandler(...)   // only if logFile != null
+    .build();
+```
+
+### 2. Mouse handler on the root focusable column
+
+Each view already has a `.onKeyEvent(handler)` on its root
+`column(dock()...).id("x").focusable()` element.  
+**Decision:** Chain `.onMouseEvent(mouseHandler)` on the same element — consistent with
+the TamboUI canonical pattern and keeps all input handling in one place per screen.
+
+### 3. Coordinate-to-list-index mapping
+
+`MouseEvent.y` is a terminal row (0-based from the top of the screen). A list rendered
+inside a `dock().center()` region starts after a fixed header height. Rather than
+hard-coding layout constants in every view, a small utility
+`TuiController.mouseRowToIndex(int mouseY, int headerRows, int rowCount)` converts a y
+coordinate to a list index:
+
+```java
+public int mouseRowToIndex(int mouseY, int headerRows, int rowCount) {
+    int idx = mouseY - headerRows;
+    if (idx < 0 || idx >= rowCount) return -1;
+    return idx;
+}
+```
+
+Header heights are small constants defined per-view (typically 1–3 rows for the header
+bar).
+
+### 4. Scroll events map directly to moveUp/moveDown
+
+`SCROLL_UP` → `controller.moveUp()` (or the view-specific equivalent).
+`SCROLL_DOWN` → `controller.moveDown()`.
+
+This is the established pattern from TamboUI's own list/tree scroll examples.
+
+### 5. Click interactions
+
+- `PRESS + LEFT`: compute index from `event.y`, call `setHighlightedIndex(idx)`.
+- `PRESS + RIGHT`: compute index, highlight it, then toggle selection.
+
+Double-click detection is deferred to a follow-up (requires timing state); not in scope.
+
+### 6. Views in scope
+
+| View | Scroll | Click | Notes |
+|---|---|---|---|
+| BrowserView | moveUp/Down | highlight + right-click select | main list only |
+| ConfirmRunView | moveRunHighlight | highlight run list | right-click toggles |
+| ExecutionResultsView | moveFileUp/Down | — | file list |
+| TagBrowserView | tag list | tag highlight | |
+| LoadConfigView | config list | config highlight | |
+| DetailView | no-op | — | no list |
+| FileDiffView | no-op | — | no list |
+| RecipeOptionsView | moveOptionHighlight | — | |
+| ExportConfigView | no-op | — | no list |

--- a/openspec/changes/tui-mouse-support-15/proposal.md
+++ b/openspec/changes/tui-mouse-support-15/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Keyboard-only navigation is functional but slow for users who prefer pointing devices.
+TamboUI 0.2.0-SNAPSHOT exposes a complete mouse-event model (`MouseEvent`, `MouseEventKind`,
+`onMouseEvent()` on any `StyledElement`, and `TuiConfig.builder().mouseCapture(true)`).
+Adding mouse support to the TUI allows users to scroll the recipe list, click to highlight
+and select recipes, and scroll result/diff views — without changing any keyboard shortcuts.
+
+## What Changes
+
+- **TUI — AtunkoTui**: Enable `mouseCapture(true)` in `TuiConfig` so the terminal backend
+  captures and routes mouse events.
+- **TUI — Views**: Add `onMouseEvent()` handlers to the focusable root element of each
+  view. Supported interactions per screen:
+  - **BrowserView** (recipe list): scroll up/down moves the highlighted recipe; left-click
+    on a row highlights that recipe; double-click (two rapid presses on same row) opens
+    detail; right-click toggles selection.
+  - **ConfirmRunView**: scroll moves run-list highlight; left-click highlights; right-click
+    toggles selection.
+  - **ExecutionResultsView**: scroll moves the file-list highlight.
+  - **TagBrowserView**: scroll + click.
+  - **LoadConfigView**: scroll + click.
+  - **DetailView / FileDiffView / ExportConfigView / RecipeOptionsView**: scroll events
+    passed through (no list to navigate, no-op or ignored).
+- **TUI — TuiController**: Add `setHighlightByMouseY(int y, int listTopY, int rowHeight,
+  int rowCount)` utility used by view mouse handlers to convert a terminal row coordinate
+  into a list index.
+
+## Capabilities
+
+### New Capabilities
+
+- `tui-mouse-support`: Enable mouse capture and handle scroll/click events in all TUI
+  screens.
+
+### Modified Capabilities
+
+- `tui-launch`: `TuiConfig` gains `mouseCapture(true)`.
+
+## Impact
+
+- `atunko-tui`: `AtunkoTui.configure()` updated; all view files gain `onMouseEvent()`
+  handlers on their root element.
+- No new library dependencies — TamboUI 0.2.0-SNAPSHOT already ships the mouse API.
+- No breaking changes to controller state API; all new controller helpers are additive.

--- a/openspec/changes/tui-mouse-support-15/tasks.md
+++ b/openspec/changes/tui-mouse-support-15/tasks.md
@@ -1,0 +1,62 @@
+## 1. Enable mouse capture in AtunkoTui
+
+- [x] 1.1 Update `AtunkoTui.configure()` to call `.mouseCapture(true)` on
+  `TuiConfig.builder()` in both branches (with/without logFile); annotate with
+  `@Requirements({"atunko:TUI_0001.27"})`
+- [x] 1.2 Add `docs/reqstool` entries: requirement `TUI_0001.27` (TUI enables mouse
+  capture so scroll and click events are delivered to handlers); add SVC
+  `SVC_TUI_0001.27` (mouse capture enabled — verified by integration that mouse events
+  are handled)
+
+## 2. TuiController — mouse helper
+
+- [x] 2.1 Add `mouseRowToIndex(int mouseY, int headerRows, int rowCount)` to
+  `TuiController` — returns list index or `-1` if out of range; annotate with
+  `@Requirements({"atunko:TUI_0001.27"})`
+- [x] 2.2 Write unit tests for `mouseRowToIndex` covering: in-range, below header,
+  above list, above row count; annotate with `@SVCs({"atunko:SVC_TUI_0001.27"})`
+
+## 3. BrowserView — mouse handler
+
+- [x] 3.1 Add `onMouseEvent()` to the root `column` in `BrowserView.render()`: handle
+  `SCROLL_UP` → `controller.moveUp()`, `SCROLL_DOWN` → `controller.moveDown()`,
+  `PRESS + LEFT` → highlight by y-coordinate, `PRESS + RIGHT` → highlight then toggle
+  selection; guard: ignore when `isSearchMode()` or `isSaveConfigMode()` or
+  `isShowHelp()` or `isShowOptions()`
+- [x] 3.2 Write unit tests for the BrowserView mouse handler: scroll moves highlight,
+  left-click sets highlight by row, right-click toggles selection; annotate with
+  `@SVCs({"atunko:SVC_TUI_0001.27"})`
+
+## 4. ConfirmRunView — mouse handler
+
+- [x] 4.1 Add `onMouseEvent()` to root `column` in `ConfirmRunView.render()`: scroll
+  → `moveRunHighlightUp/Down`, left-click → highlight run list by y-coordinate,
+  right-click → highlight then toggle run recipe; guard: ignore when `isShowHelp()`,
+  `isShowOptions()`, or `isShowExport()`
+
+## 5. ExecutionResultsView — mouse handler
+
+- [x] 5.1 Add `onMouseEvent()` to root `column` in `ExecutionResultsView.render()`:
+  `SCROLL_UP` → `moveFileUp`, `SCROLL_DOWN` → `moveFileDown`
+
+## 6. TagBrowserView — mouse handler
+
+- [x] 6.1 Add `onMouseEvent()` to root `column` in `TagBrowserView.render()`: scroll
+  moves tag-list highlight; read the existing controller methods used for Up/Down
+  navigation and wire scroll to those
+
+## 7. LoadConfigView — mouse handler
+
+- [x] 7.1 Add `onMouseEvent()` to root `column` in `LoadConfigView.render()`: scroll →
+  `moveLoadConfigUp/Down`; left-click → highlight by y-coordinate
+
+## 8. RecipeOptionsView — mouse handler
+
+- [x] 8.1 Add `onMouseEvent()` to root `column` in `RecipeOptionsView.render()`: scroll
+  → `moveOptionHighlightUp/Down` using current option count
+
+## 9. Build and Quality
+
+- [x] 9.1 Run `./gradlew spotlessApply` and fix any formatting issues
+- [x] 9.2 Run `./gradlew build` — confirm no Checkstyle or Error Prone violations
+- [x] 9.3 Run `./gradlew test` — confirm all tests pass


### PR DESCRIPTION
## Summary

- Enables OS-level mouse capture in `AtunkoTui.configure()` (`mouseCapture(true)`) for both the default and log-file config branches
- Adds `TuiController.mouseRowToIndex()` for converting terminal y-coordinates to list indices
- Adds `onMouseEvent()` handlers to all TUI views: `BrowserView`, `ConfirmRunView`, `ExecutionResultsView`, `TagBrowserView`, `LoadConfigView`, `RecipeOptionsView`
  - Scroll up/down navigates the list in each view
  - Left-click highlights by row; right-click highlights and toggles selection (where applicable)
- Adds requirement `TUI_0001.27` and SVC `SVC_TUI_0001.27` to reqstool docs
- Adds 9 new unit tests (`mouseRowToIndex` × 4, `BrowserViewMouseTest` × 5)

## Test plan

- [x] `./gradlew spotlessApply` — no formatting issues
- [x] `./gradlew build` — no Checkstyle or Error Prone violations
- [x] `./gradlew :atunko-tui:cleanTest :atunko-tui:test` — all tests pass (including new mouse tests)