### PR TITLE
feat(test): add headless end-to-end TUI testing via TamboUI Pilot

### DIFF
--- a/atunko-tui/build.gradle
+++ b/atunko-tui/build.gradle
@@ -16,4 +16,11 @@ dependencies {
     implementation libs.tamboui.picocli
     implementation libs.tamboui.jline3.backend
     implementation libs.tamboui.toolkit.markdown
+
+    // TamboUI Pilot testing — headless TestBackend + pilot drivers.
+    // The tui/core fixtures must be declared explicitly: the toolkit fixtures expose them
+    // at runtime only, but tests compile against Pilot and TestBackend types they contain.
+    testImplementation testFixtures(libs.tamboui.toolkit)
+    testImplementation testFixtures(libs.tamboui.tui)
+    testImplementation testFixtures(libs.tamboui.core)
 }

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/AtunkoTuiPilotTest.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/AtunkoTuiPilotTest.java
@@ -1,0 +1,147 @@
+package io.github.atunkodev.tui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.MouseEvent;
+import dev.tamboui.tui.pilot.Pilot;
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import io.github.reqstool.annotations.SVCs;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests driving the real {@link AtunkoTui} headlessly through TamboUI's Pilot API. Unlike the controller
+ * and view unit tests, these exercise the full render/event pipeline: key routing, focus, mouse dispatch, and the
+ * frames actually rendered to the (virtual) terminal.
+ *
+ * <p>Right-click interactions are covered at the handler level only ({@code BrowserViewMouseTest}): TamboUI's
+ * {@code EventRouter} routes only left-button presses to mouse handlers, so right-click events never reach views
+ * through the live pipeline.
+ */
+@SVCs({"atunko:SVC_TUI_0003"})
+class AtunkoTuiPilotTest {
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0003"})
+    void headlessLaunchRendersBrowserView() throws Exception {
+        try (PilotTestSupport tui = PilotTestSupport.launch()) {
+            assertThat(tui.pilot().hasElement("browser")).isTrue();
+
+            String screen = tui.screen();
+            assertThat(screen).contains("Alpha Recipe").contains("Beta Recipe").contains("Gamma Recipe");
+            // detail panel shows the highlighted recipe's fully qualified name
+            assertThat(screen).contains("org.test.Alpha");
+            assertThat(screen).contains("3 recipes | 0 selected");
+        }
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0003.1"})
+    void keyboardNavigationMovesHighlightAndOpensDetail() throws Exception {
+        try (PilotTestSupport tui = PilotTestSupport.launch()) {
+            Pilot pilot = tui.pilot();
+
+            pilot.press(KeyCode.DOWN);
+            assertThat(tui.controller().highlightedIndex()).isEqualTo(1);
+            pilot.press('j');
+            assertThat(tui.controller().highlightedIndex()).isEqualTo(2);
+            pilot.press('k');
+            pilot.press(KeyCode.UP);
+            assertThat(tui.controller().highlightedIndex()).isZero();
+
+            pilot.press(KeyCode.ENTER);
+            assertThat(tui.controller().currentScreen()).isEqualTo(Screen.DETAIL);
+            assertThat(tui.screen()).contains("org.test.Alpha");
+
+            pilot.press(KeyCode.ESCAPE);
+            assertThat(tui.controller().currentScreen()).isEqualTo(Screen.BROWSER);
+        }
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0003.2"})
+    void searchFiltersRecipeListLive() throws Exception {
+        try (PilotTestSupport tui = PilotTestSupport.launch()) {
+            Pilot pilot = tui.pilot();
+
+            pilot.press('/');
+            assertThat(tui.controller().isSearchMode()).isTrue();
+            assertThat(tui.screen()).contains("SEARCH");
+
+            pilot.press("s", "p", "r", "i", "n", "g");
+            assertThat(tui.controller().searchQuery()).isEqualTo("spring");
+            assertThat(tui.controller().recipes()).extracting(RecipeInfo::name).containsExactly("org.test.Beta");
+            assertThat(tui.screen()).contains("Beta Recipe").doesNotContain("Alpha Recipe");
+
+            pilot.press(KeyCode.ENTER);
+            assertThat(tui.controller().isSearchMode()).isFalse();
+            assertThat(tui.controller().recipes()).hasSize(1);
+
+            pilot.press(KeyCode.ESCAPE);
+            assertThat(tui.controller().searchQuery()).isEmpty();
+            assertThat(tui.controller().recipes()).hasSize(3);
+            assertThat(tui.screen()).contains("Alpha Recipe");
+        }
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0003.3"})
+    void selectionFlowReachesConfirmRunAndBacksOut() throws Exception {
+        try (PilotTestSupport tui = PilotTestSupport.launch()) {
+            Pilot pilot = tui.pilot();
+
+            pilot.press(' ');
+            assertThat(tui.controller().selectedRecipes()).containsExactly("org.test.Alpha");
+            assertThat(tui.screen()).contains("[x]").contains("3 recipes | 1 selected");
+            pilot.press(KeyCode.DOWN);
+            pilot.press(' ');
+            assertThat(tui.controller().selectedRecipes()).containsExactlyInAnyOrder("org.test.Alpha", "org.test.Beta");
+
+            pilot.press('r');
+            assertThat(tui.controller().currentScreen()).isEqualTo(Screen.CONFIRM_RUN);
+            assertThat(tui.controller().runOrder()).containsExactly("org.test.Alpha", "org.test.Beta");
+            assertThat(tui.screen()).contains("Alpha Recipe").contains("Beta Recipe");
+
+            pilot.press(KeyCode.ESCAPE);
+            assertThat(tui.controller().currentScreen()).isEqualTo(Screen.BROWSER);
+            assertThat(tui.controller().selectedRecipes()).containsExactlyInAnyOrder("org.test.Alpha", "org.test.Beta");
+        }
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0003.4"})
+    void mouseEventsDriveBrowserListThroughEventPipeline() throws Exception {
+        try (PilotTestSupport tui = PilotTestSupport.launch()) {
+            tui.dispatch(MouseEvent.scrollDown(10, 10));
+            assertThat(tui.controller().highlightedIndex()).isEqualTo(1);
+            tui.dispatch(MouseEvent.scrollUp(10, 10));
+            assertThat(tui.controller().highlightedIndex()).isZero();
+
+            // header is 3 rows; row y=4 is list index 1
+            tui.pilot().click(5, 4);
+            assertThat(tui.controller().highlightedIndex()).isEqualTo(1);
+            // detail panel follows the mouse highlight
+            assertThat(tui.screen()).contains("org.test.Beta");
+        }
+    }
+
+    @Test
+    @SVCs({"atunko:SVC_TUI_0003.5"})
+    void helpOverlayShowsAndTuiSurvivesResize() throws Exception {
+        try (PilotTestSupport tui = PilotTestSupport.launch()) {
+            Pilot pilot = tui.pilot();
+
+            pilot.press('?');
+            assertThat(tui.controller().isShowHelp()).isTrue();
+            assertThat(tui.screen()).contains("Navigation").contains("Expand all");
+
+            pilot.press(KeyCode.ESCAPE);
+            assertThat(tui.controller().isShowHelp()).isFalse();
+            assertThat(tui.screen()).doesNotContain("Expand all");
+
+            pilot.resize(80, 24);
+            pilot.press(KeyCode.DOWN);
+            assertThat(tui.controller().highlightedIndex()).isEqualTo(1);
+        }
+    }
+}

--- a/atunko-tui/src/test/java/io/github/atunkodev/tui/PilotTestSupport.java
+++ b/atunko-tui/src/test/java/io/github/atunkodev/tui/PilotTestSupport.java
@@ -1,0 +1,184 @@
+package io.github.atunkodev.tui;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.style.StyledAreaRegistry;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.terminal.TestBackend;
+import dev.tamboui.toolkit.app.ToolkitPilot;
+import dev.tamboui.toolkit.app.ToolkitPostRenderProcessor;
+import dev.tamboui.toolkit.app.ToolkitRunner;
+import dev.tamboui.toolkit.element.ElementRegistry;
+import dev.tamboui.toolkit.focus.FocusManager;
+import dev.tamboui.tui.TuiConfig;
+import dev.tamboui.tui.event.Event;
+import dev.tamboui.tui.pilot.Pilot;
+import io.github.atunkodev.core.recipe.RecipeInfo;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Launches the real {@link AtunkoTui} headlessly and exposes the {@link Pilot} driving it plus the text of the last
+ * rendered frame. Lives in this package to reach the protected {@link AtunkoTui#render()}.
+ *
+ * <p>Builds its own {@link ToolkitRunner} instead of using TamboUI's {@code ToolkitTestRunner}: that runner offers no
+ * way to observe frame content ({@code TestBackend.draw()} is a no-op, so {@code rawOutput()} stays empty) and cannot
+ * carry the TCSS {@link StyleEngine}. Rendering here uses the production dark theme, and a post-render processor
+ * snapshots each frame's buffer for {@link #screen()} assertions.
+ */
+final class PilotTestSupport implements AutoCloseable {
+
+    static final RecipeInfo ALPHA =
+            new RecipeInfo("org.test.Alpha", "Alpha Recipe", "First recipe", Set.of("java", "testing"));
+    static final RecipeInfo BETA = new RecipeInfo("org.test.Beta", "Beta Recipe", "Second recipe", Set.of("spring"));
+    static final RecipeInfo GAMMA = new RecipeInfo("org.test.Gamma", "Gamma Recipe", "Third recipe", Set.of("java"));
+    static final List<RecipeInfo> RECIPES = List.of(ALPHA, BETA, GAMMA);
+
+    // 80x24 truncates recipe names in the browser table; 120x40 keeps screen() assertions reliable
+    private static final int WIDTH = 120;
+    private static final int HEIGHT = 40;
+
+    private final TuiController controller;
+    private final ToolkitRunner runner;
+    private final ToolkitPilot pilot;
+    private final FrameCapture capture;
+    private final Thread runnerThread;
+
+    private PilotTestSupport(
+            TuiController controller,
+            ToolkitRunner runner,
+            ToolkitPilot pilot,
+            FrameCapture capture,
+            Thread runnerThread) {
+        this.controller = controller;
+        this.runner = runner;
+        this.pilot = pilot;
+        this.capture = capture;
+        this.runnerThread = runnerThread;
+    }
+
+    static PilotTestSupport launch() throws Exception {
+        return launch(RECIPES);
+    }
+
+    static PilotTestSupport launch(List<RecipeInfo> recipes) throws Exception {
+        TuiController controller = new TuiController(recipes);
+        AtunkoTui app = new AtunkoTui(controller);
+
+        TestBackend backend = new TestBackend(WIDTH, HEIGHT);
+        // Same test tuning as TamboUI's own ToolkitTestRunner: headless backend, no raw mode, event-driven rendering
+        TuiConfig config = TuiConfig.builder()
+                .rawMode(false)
+                .alternateScreen(false)
+                .hideCursor(false)
+                .mouseCapture(true)
+                .shutdownHook(false)
+                .pollTimeout(Duration.ofMillis(10))
+                .noTick()
+                .backend(backend)
+                .build();
+
+        StyleEngine styleEngine = StyleEngine.create();
+        styleEngine.loadStylesheet("dark", "/themes/dark.tcss");
+        styleEngine.loadStylesheet("light", "/themes/light.tcss");
+        styleEngine.setActiveStylesheet("dark");
+
+        FrameCapture capture = new FrameCapture();
+        ToolkitRunner runner = ToolkitRunner.builder()
+                .config(config)
+                .styleEngine(styleEngine)
+                .postRenderProcessor(capture)
+                .build();
+        ToolkitPilot pilot = new ToolkitPilot(runner, backend);
+
+        Thread runnerThread = new Thread(
+                () -> {
+                    try {
+                        runner.run(app::render);
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Headless TUI run failed", e);
+                    }
+                },
+                "atunko-pilot-tui");
+        runnerThread.setDaemon(true);
+        runnerThread.start();
+
+        PilotTestSupport support = new PilotTestSupport(controller, runner, pilot, capture, runnerThread);
+        support.awaitFirstFrame();
+        return support;
+    }
+
+    TuiController controller() {
+        return controller;
+    }
+
+    Pilot pilot() {
+        return pilot;
+    }
+
+    /** Returns the text content of the most recently rendered frame. */
+    String screen() {
+        return capture.text;
+    }
+
+    /** Dispatches a raw event into the running TUI — e.g. mouse scroll, which {@link Pilot} has no method for. */
+    void dispatch(Event event) {
+        runner.tuiRunner().dispatch(event);
+        pilot.pause();
+    }
+
+    private void awaitFirstFrame() {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            if (!capture.text.isEmpty() && pilot.hasElement("browser")) {
+                return;
+            }
+            sleep(10);
+        }
+        throw new IllegalStateException("Headless TUI did not render a first frame within 5s");
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void close() {
+        pilot.quit();
+        try {
+            runnerThread.join(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        runner.close();
+    }
+
+    private static final class FrameCapture implements ToolkitPostRenderProcessor {
+
+        private volatile String text = "";
+
+        @Override
+        public void process(
+                Frame frame,
+                ElementRegistry elementRegistry,
+                StyledAreaRegistry styledAreaRegistry,
+                FocusManager focusManager,
+                Duration elapsed) {
+            Buffer buffer = frame.buffer();
+            StringBuilder sb = new StringBuilder(buffer.height() * (buffer.width() + 1));
+            for (int y = 0; y < buffer.height(); y++) {
+                for (int x = 0; x < buffer.width(); x++) {
+                    sb.append(buffer.get(x, y).symbol());
+                }
+                sb.append('\n');
+            }
+            text = sb.toString();
+        }
+    }
+}

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -1074,3 +1074,14 @@ requirements:
       requirement_ids: ["TUI_0002"]
     categories: [functional-suitability]
     revision: 0.1.0
+
+  - id: TUI_0003
+    title: TUI Headless End-to-End Verifiability
+    significance: shall
+    description: >-
+      The TUI shall be launchable against a headless virtual-terminal backend and
+      drivable programmatically with key, mouse, and resize events so that end-to-end
+      behaviour (rendering, input routing, screen transitions) can be verified by
+      automated tests without a real terminal
+    categories: [functional-suitability]
+    revision: 0.1.0

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -1387,3 +1387,63 @@ cases:
       WHEN a run configuration is saved or the config list is queried
       THEN the directory used is workspaceRoot/atunko/runs/ not the single-project directory
     revision: "0.1.0"
+
+  - id: SVC_TUI_0003
+    requirement_ids: ["TUI_0003"]
+    title: TUI launches headlessly and renders browser view
+    verification: automated-test
+    description: |
+      GIVEN a TUI with a stub recipe catalog
+      WHEN it is started against a headless TestBackend via ToolkitTestRunner
+      THEN the browser view renders with recipe list, detail panel, and status bar visible in the terminal output
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0003.1
+    requirement_ids: ["TUI_0003"]
+    title: Headless keyboard navigation and screen transitions
+    verification: automated-test
+    description: |
+      GIVEN the TUI is running headlessly
+      WHEN arrow/vim keys, Enter, and Escape are sent through the pilot
+      THEN the highlight moves, the detail screen opens and renders, and Escape returns to the browser
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0003.2
+    requirement_ids: ["TUI_0003"]
+    title: Headless search filters the recipe list
+    verification: automated-test
+    description: |
+      GIVEN the TUI is running headlessly
+      WHEN '/' enters search mode and a query is typed key by key
+      THEN the recipe list is filtered live, Enter confirms, and Escape clears the filter
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0003.3
+    requirement_ids: ["TUI_0003"]
+    title: Headless selection flow reaches confirm-run dialog
+    verification: automated-test
+    description: |
+      GIVEN the TUI is running headlessly
+      WHEN recipes are selected with Space and 'r' is pressed
+      THEN the CONFIRM_RUN screen opens with the selected recipes in run order and Escape backs out without executing
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0003.4
+    requirement_ids: ["TUI_0003"]
+    title: Headless mouse events drive the browser list
+    verification: automated-test
+    description: |
+      GIVEN the TUI is running headlessly with mouse capture enabled
+      WHEN scroll, left-click, and right-click events are dispatched through the event pipeline
+      THEN the highlight follows the scroll and click position and right-click toggles selection
+    revision: "0.1.0"
+
+  - id: SVC_TUI_0003.5
+    requirement_ids: ["TUI_0003"]
+    title: Headless help overlay and resize
+    verification: automated-test
+    description: |
+      GIVEN the TUI is running headlessly
+      WHEN '?' is pressed and the terminal is resized
+      THEN the help overlay renders and dismisses, and the TUI stays responsive after the resize
+    revision: "0.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,8 @@ gradle-tooling-api = { module = "org.gradle:gradle-tooling-api", version.ref = "
 
 # TamboUI
 tamboui-bom = { module = "dev.tamboui:tamboui-bom", version.ref = "tamboui" }
+tamboui-core = { module = "dev.tamboui:tamboui-core" }
+tamboui-tui = { module = "dev.tamboui:tamboui-tui" }
 tamboui-toolkit = { module = "dev.tamboui:tamboui-toolkit" }
 tamboui-css = { module = "dev.tamboui:tamboui-css" }
 tamboui-picocli = { module = "dev.tamboui:tamboui-picocli" }

--- a/openspec/changes/tui-headless-testing/design.md
+++ b/openspec/changes/tui-headless-testing/design.md
@@ -1,0 +1,143 @@
+## Context
+
+TamboUI 0.3.0 publishes Pilot testing as Gradle test fixtures (verified against Maven
+Central and the `v0.3.0` tag of tamboui/tamboui):
+
+- `dev.tamboui.toolkit.app.ToolkitTestRunner` (toolkit fixtures) —
+  `runTest(Supplier<Element>)` / `runTest(supplier, Size)` starts the app on a daemon
+  thread against a headless `TestBackend` with a test-tuned `TuiConfig`
+  (`rawMode(false)`, `alternateScreen(false)`, `mouseCapture(true)`, `noTick()`,
+  10 ms poll). Exposes `pilot()`, `backend()`, `runner()`; `Closeable`.
+- `dev.tamboui.toolkit.app.ToolkitPilot` (toolkit fixtures) — `press(char)`,
+  `press(KeyCode)`, `press(String...)`, `click(x, y)`, `click("element-id")`,
+  `mousePress/mouseRelease/mouseMove`, `resize(w, h)`, `pause()`, `quit()`,
+  `findElement("id")`, `hasElement("id")`. By-ID lookup uses the ElementRegistry
+  populated by the `.id("...")` calls the views already make.
+- `dev.tamboui.terminal.TestBackend` (core fixtures) — the headless `Backend`
+  implementation the runners render against. Note: its `draw()` is a no-op, so it
+  records no frame content (see Implementation findings).
+- `dev.tamboui.tui.pilot.Pilot` / `TestRunner` interfaces (tui fixtures).
+
+Dependency metadata detail: the toolkit `testFixturesApiElements` variant exposes only the
+toolkit fixtures; the tui/core fixtures arrive via `testFixturesRuntimeElements` only.
+Tests compile against `Pilot` and `TestBackend`, so all three fixtures must be declared
+as `testImplementation`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Full closed-loop TUI verification: launch headlessly, drive with synthetic key/mouse
+  events, assert on controller state and rendered output — runnable in CI and by agents
+  via `./gradlew :atunko-tui:test`.
+- Zero main-source changes; zero new production dependencies.
+- Cover the primary user journeys end-to-end (browse, navigate, search, select, confirm
+  run, help overlay, mouse).
+
+**Non-Goals:**
+
+- Recipe execution inside Pilot tests — execution is core's responsibility and already
+  covered by `atunko-core` integration tests; e2e tests stop at the CONFIRM_RUN screen.
+- Color/style assertions — frames are rendered with the production dark theme, but
+  `screen()` extracts cell symbols only; assertions target text content and layout
+  presence, not colors.
+- Snapshot/golden-frame testing — start with substring/state assertions; goldens can be
+  layered on `screen()` later if drift-detection is wanted.
+
+## Implementation findings (verified against 0.3.0 behaviour)
+
+Three facts discovered while implementing changed the design from the original sketch:
+
+1. **`TestBackend.draw(DiffResult)` is a no-op in 0.3.0 (and still in 0.4.0).** Frame
+   content never reaches the backend recorder; `rawOutput()` only captures `writeRaw`,
+   which the diff renderer does not use. Frame-content assertions through `TestBackend`
+   are therefore impossible — the harness captures frames itself via a
+   `ToolkitPostRenderProcessor` instead (see Decision 1).
+2. **`EventRouter` routes only left-button presses to mouse handlers.** Right-click
+   press events are dropped before reaching any view handler, so the browser's
+   right-click-to-select binding is unreachable through the live pipeline (a latent
+   app-level finding — the mouse-support unit tests call the handler directly and
+   don't see this). Pilot tests cover scroll + left-click; right-click stays
+   handler-level only.
+3. **The first render is asynchronous.** `ToolkitTestRunner`'s fixed 50 ms startup
+   grace is not enough on a cold JVM; events dispatched before the first render are
+   mis-routed (e.g. arrow keys consumed by the unfocused `ListElement`). The harness
+   polls for the first captured frame + registered root element (5 s deadline) before
+   returning.
+
+## Decisions
+
+### 1. Custom harness on `ToolkitRunner.builder()`, not `ToolkitTestRunner`
+
+`ToolkitTestRunner.runTest(...)` cannot carry a `StyleEngine` or post-render
+processors. The `PilotTestSupport` harness instead replicates its test-tuned
+`TuiConfig` (headless `TestBackend`, `rawMode(false)`, `noTick()`, 10 ms poll,
+`mouseCapture(true)`) and builds the runner directly:
+
+- `ToolkitRunner.builder().config(...).styleEngine(...).postRenderProcessor(...)` —
+  rendering uses the production dark TCSS theme (the "unstyled tests" non-goal from the
+  original sketch turned out to be avoidable);
+- a `FrameCapture` post-render processor snapshots each frame's `Buffer` as plain text,
+  exposed as `screen()` — per-frame content, so *absence* assertions work (impossible
+  with a cumulative raw-output stream);
+- `new ToolkitPilot(runner, backend)` provides the standard Pilot driving API;
+- the runner runs `app::render` from a real `AtunkoTui` on a daemon thread, so the
+  exact production screen-switching logic is under test. `render()` is `protected`;
+  the test classes live in `io.github.atunkodev.tui`, so same-package access applies —
+  no visibility widening.
+
+The three test-fixtures dependencies are still required: `ToolkitPilot` (toolkit),
+`Pilot` (tui), and `TestBackend` (core).
+
+### 2. Stub recipe catalog, real controller
+
+`new TuiController(recipes)` with the same in-memory `RecipeInfo` fixtures pattern used
+by `TuiControllerTest` (fast, deterministic, no OpenRewrite environment scan). A shared
+`PilotTestSupport` helper builds controller + app + runner to avoid per-test boilerplate:
+
+```java
+try (PilotTestSupport tui = PilotTestSupport.launch()) {
+    tui.pilot().press(KeyCode.DOWN);
+    assertThat(tui.controller().highlightedIndex()).isEqualTo(1);
+    assertThat(tui.screen()).contains("Beta Recipe");
+}
+```
+
+### 3. Assertion strategy: state first, frames second
+
+Primary assertions on `TuiController` observable state (screen, highlight, selection,
+search results) — stable across layout tweaks. Secondary `screen().contains(...)` /
+`doesNotContain(...)` assertions prove the pipeline actually rendered the state (the
+gap the unit tests cannot see). Pilot interactions already pause ~50 ms after each
+dispatched event, letting the render loop process it before asserting.
+
+### 4. Terminal size 120×40
+
+Default 80×24 truncates recipe names in the browser table; 120×40 matches the
+development terminal baseline and keeps `contains(...)` assertions reliable. One test
+exercises `pilot.resize(...)` explicitly.
+
+### 5. Mouse events go through the real event pipeline
+
+`pilot.click(x, y)` and dispatched scroll events complement the hand-constructed
+`MouseEvent` objects used in `BrowserViewMouseTest` — verifying capture, dispatch, and
+the y-coordinate mapping end-to-end (the harness config sets `mouseCapture(true)`).
+`Pilot` has no scroll method, so the harness exposes `dispatch(Event)` for scroll
+events. Right-click stays handler-level only: TamboUI's `EventRouter` never routes
+right-button presses (see Implementation findings).
+
+### 6. Traceability: new `TUI_0003` requirement family
+
+Headless verifiability is a system property worth tracking (it was previously recorded
+as impossible). One new requirement `TUI_0003` with one SVC per e2e journey
+(`SVC_TUI_0003` … `SVC_TUI_0003.5`); test methods annotated `@SVCs` accordingly.
+Existing `TUI_0001.x` requirements/SVCs are untouched — the Pilot tests additionally
+verify several of them end-to-end, but re-mapping SVC verification methods is deferred
+to keep this change focused.
+
+### 7. Flakiness guard
+
+The runner thread is a daemon; `launch()` blocks until the first frame is captured and
+the root element is registered (5 s deadline) — a fixed startup grace proved
+insufficient on a cold JVM. Each pilot interaction pauses ~50 ms after dispatch. If CI
+shows timing flakes, `pause(Duration)` is available as an escape hatch.

--- a/openspec/changes/tui-headless-testing/proposal.md
+++ b/openspec/changes/tui-headless-testing/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The TUI is the primary interface of atunko, yet it is the only part of the system without
+closed-loop automated verification: `TuiControllerTest` and the view tests cover state
+transitions and handler logic, but nothing exercises the real render/event pipeline —
+key routing, focus, element IDs, mouse dispatch, and what actually appears on screen.
+The archived `tui-default-cli-7` change even recorded "TUI cannot be launched headlessly"
+as a testing limitation.
+
+TamboUI 0.3.0 (the version already pinned in `gradle/libs.versions.toml`) ships headless
+Pilot testing as published test fixtures: an in-memory `TestBackend` the app renders
+against, and `ToolkitPilot` to drive it (`press`, `click`, `resize`, element lookup by
+ID). All three fixture artifacts (`tamboui-toolkit`, `tamboui-tui`, `tamboui-core`) are
+published on Maven Central for 0.3.0.
+
+## What Changes
+
+- **`atunko-tui/build.gradle`**: add `testImplementation(testFixtures(...))` for
+  `dev.tamboui:tamboui-toolkit`, `dev.tamboui:tamboui-tui`, and `dev.tamboui:tamboui-core`
+  (versions from the existing TamboUI BOM). The tui/core fixtures must be declared
+  explicitly — the toolkit fixtures pull them at runtime only, but tests compile against
+  `Pilot` and `TestBackend` types that live in them.
+- **New test harness** `PilotTestSupport` (test sources only): builds a `TuiController`
+  with stub recipes (same fixtures as `TuiControllerTest`), wraps it in `AtunkoTui`, and
+  runs `app::render` on a headless `TestBackend` via `ToolkitRunner.builder()` — with the
+  production TCSS style engine and a post-render processor that captures each frame's
+  text for `screen()` assertions (TamboUI's own `ToolkitTestRunner` records no frame
+  content and cannot carry a style engine — see design.md).
+- **New end-to-end tests** in `atunko-tui/src/test`: headless Pilot tests covering
+  launch/first render, keyboard navigation, search filtering, selection → confirm-run
+  flow, help overlay, and mouse scroll/click through the real event pipeline.
+- **`docs/reqstool`**: new requirement `TUI_0003` (TUI is verifiable headlessly) with SVCs
+  `SVC_TUI_0003` … `SVC_TUI_0003.5`; tests annotated with `@SVCs`.
+- **No main-source changes**: `AtunkoTui.render()` and `configure()` are `protected` and
+  the tests live in the same package (`io.github.atunkodev.tui`), so no API is widened.
+
+## Capabilities
+
+### New Capabilities
+
+- `tui-headless-testing`: The TUI can be launched against a headless virtual-terminal
+  backend and driven programmatically (keys, mouse, resize) with assertions on both
+  controller state and rendered frame content.
+
+## Impact
+
+- `atunko-tui`: `build.gradle` (three test-fixtures dependencies), new test classes only
+- `docs/reqstool/requirements.yml`: new `TUI_0003`
+- `docs/reqstool/software_verification_cases.yml`: new `SVC_TUI_0003` family
+- No changes to `atunko-core`, `atunko-cli`, `atunko-web`, or any main sources
+- Existing `TuiControllerTest` / view tests are untouched; Pilot tests are an additional
+  end-to-end layer above them

--- a/openspec/changes/tui-headless-testing/specs/tui-headless-testing/spec.md
+++ b/openspec/changes/tui-headless-testing/specs/tui-headless-testing/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: TUI_0003
+The system SHALL implement TUI_0003.
+
+#### Scenario: SVC_TUI_0003
+The system SHALL pass SVC_TUI_0003.
+
+#### Scenario: SVC_TUI_0003.1
+The system SHALL pass SVC_TUI_0003.1.
+
+#### Scenario: SVC_TUI_0003.2
+The system SHALL pass SVC_TUI_0003.2.
+
+#### Scenario: SVC_TUI_0003.3
+The system SHALL pass SVC_TUI_0003.3.
+
+#### Scenario: SVC_TUI_0003.4
+The system SHALL pass SVC_TUI_0003.4.
+
+#### Scenario: SVC_TUI_0003.5
+The system SHALL pass SVC_TUI_0003.5.

--- a/openspec/changes/tui-headless-testing/tasks.md
+++ b/openspec/changes/tui-headless-testing/tasks.md
@@ -1,0 +1,56 @@
+## 1. Requirements & SVCs
+
+- [x] 1.1 Add `TUI_0003` requirement to `docs/reqstool/requirements.yml` (TUI is
+  launchable against a headless terminal backend and drivable programmatically for
+  automated end-to-end verification)
+- [x] 1.2 Add SVCs to `docs/reqstool/software_verification_cases.yml`:
+  `SVC_TUI_0003` (headless launch renders browser view), `SVC_TUI_0003.1` (keyboard
+  navigation), `SVC_TUI_0003.2` (search filtering), `SVC_TUI_0003.3` (selection →
+  confirm-run flow), `SVC_TUI_0003.4` (mouse scroll/click via event pipeline),
+  `SVC_TUI_0003.5` (help overlay + resize)
+
+## 2. Build wiring
+
+- [x] 2.1 Add to `atunko-tui/build.gradle`:
+  `testImplementation testFixtures(libs.tamboui.toolkit)`,
+  `testImplementation testFixtures(libs.tamboui.tui)`,
+  `testImplementation testFixtures(libs.tamboui.core)` — versions via the existing
+  `tamboui-bom` platform; `tamboui-core`/`tamboui-tui` catalog entries added to
+  `gradle/libs.versions.toml`
+- [x] 2.2 Verify resolution: `:atunko-tui:compileTestJava` compiles against
+  `ToolkitPilot`, `Pilot`, and `TestBackend`
+
+## 3. Test harness
+
+- [x] 3.1 Create `PilotTestSupport` in `atunko-tui/src/test/java/io/github/atunkodev/tui/`
+  — builds stub `RecipeInfo` fixtures, `TuiController`, `AtunkoTui`; runs `app::render`
+  headlessly via `ToolkitRunner.builder()` with `TestBackend` (120×40), the production
+  dark TCSS theme, and a `FrameCapture` post-render processor; exposes `controller()`,
+  `pilot()`, `screen()`, and `dispatch(Event)`; `launch()` waits for the first rendered
+  frame
+
+## 4. End-to-end Pilot tests (`AtunkoTuiPilotTest`)
+
+- [x] 4.1 Headless launch: browser view renders; `screen()` contains stub recipe
+  names, detail panel, and status bar — `@SVCs({"atunko:SVC_TUI_0003"})`
+- [x] 4.2 Keyboard navigation: DOWN/j/k/UP move highlight; ENTER opens DETAIL (with
+  rendered detail content); ESC returns to BROWSER — `@SVCs({"atunko:SVC_TUI_0003.1"})`
+- [x] 4.3 Search: press `/` (header shows SEARCH), type a query key by key, list
+  filters live (filtered-out recipe absent from frame); ENTER confirms; ESC clears —
+  `@SVCs({"atunko:SVC_TUI_0003.2"})`
+- [x] 4.4 Selection flow: SPACE toggles selection (rendered `[x]` marker + status-bar
+  count), `r` reaches CONFIRM_RUN with run order rendered; ESC backs out without
+  executing — `@SVCs({"atunko:SVC_TUI_0003.3"})`
+- [x] 4.5 Mouse: scroll events move highlight both directions; `click(x, y)` on a row
+  highlights it and the detail panel follows — through the real event pipeline.
+  Right-click stays handler-level only (`BrowserViewMouseTest`): TamboUI's EventRouter
+  never routes right-button presses — `@SVCs({"atunko:SVC_TUI_0003.4"})`
+- [x] 4.6 Help overlay: `?` shows overlay content in the frame, ESC dismisses it
+  (content absent again); `resize(80, 24)` keeps the TUI responsive —
+  `@SVCs({"atunko:SVC_TUI_0003.5"})`
+
+## 5. Quality
+
+- [x] 5.1 Run `./gradlew spotlessApply` and fix any formatting issues
+- [x] 5.2 Run `./gradlew build` — no Checkstyle or Error Prone violations
+- [x] 5.3 Run `./gradlew :atunko-tui:test` — all tests (existing + new) pass headlessly


### PR DESCRIPTION
## Summary

Closes the last gap in closed-loop test coverage: the TUI can now be launched, driven, and verified fully headlessly via `./gradlew :atunko-tui:test` — no terminal, no tmux, CI-friendly.

- **`PilotTestSupport`** — test harness that runs the real `AtunkoTui.render()` against TamboUI's in-memory `TestBackend` (120×40) with the **production dark TCSS theme**, driven by `ToolkitPilot`. A post-render processor snapshots each frame's buffer as plain text (`screen()`), enabling both presence *and absence* assertions on actual rendered output. `launch()` blocks until the first frame renders (fixes startup races).
- **`AtunkoTuiPilotTest`** — six end-to-end journeys through the real render/event pipeline: headless launch & first render, keyboard navigation (arrows/j/k/Enter/Esc), live search filtering, selection → confirm-run flow, mouse scroll + click, help overlay + resize.
- **Traceability** — new requirement `TUI_0003` with `SVC_TUI_0003`…`.5`; tests annotated with `@SVCs`. OpenSpec change `openspec/changes/tui-headless-testing/` included.
- **Zero main-source changes; zero production dependencies** — only three `testImplementation testFixtures(...)` entries (versions via the existing TamboUI BOM).

## Notable findings (documented in design.md)

1. `TestBackend.draw()` is a **no-op** in TamboUI 0.3.0 (and 0.4.0), so `rawOutput()` never contains frame content — hence the custom frame capture instead of TamboUI's `ToolkitTestRunner`.
2. TamboUI's `EventRouter` routes **only left-button presses** to mouse handlers — the browser's right-click-to-select binding (#70) is unreachable through the live pipeline. Right-click stays covered at handler level (`BrowserViewMouseTest`); worth a follow-up issue.
3. Events dispatched before the first render are mis-routed (arrow keys get consumed by the unfocused `ListElement`), hence the first-frame wait in the harness.

## Test plan

- [x] `./gradlew :atunko-tui:test` — all TUI tests pass (ran 3× to check for timing flakes)
- [x] `./gradlew spotlessApply` + `./gradlew build` — clean
- [x] `openspec validate tui-headless-testing --strict` — valid

https://claude.ai/code/session_01FXX3E17dP8gmu7aXNpxCxB