### PR TITLE
chore(deps): upgrade TamboUI 0.3.0 → 0.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 openrewrite-bom = "3.25.0"
 picocli = "4.7.7"
 gradle-tooling-api = "9.3.1"
-tamboui = "0.3.0"
+tamboui = "0.4.0"
 reqstool-annotations = "1.0.0"
 junit = "5.11.4"
 assertj = "3.27.3"

--- a/openspec/changes/tamboui-0.4.0-upgrade/proposal.md
+++ b/openspec/changes/tamboui-0.4.0-upgrade/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+atunko pins TamboUI 0.3.0; 0.4.0 is the latest release (2026-06-18). The release brings
+keyboard/bindings reliability fixes directly relevant to atunko (`Builder.bindings()`
+propagation, Shift+F1–F4 parsing, Windows arrow-key fix in the Panama backend), a
+`ScrollableElement` container, panel title alignment, and new sparkline widgets that may
+be useful for future TUI features. No breaking API changes are advertised; the only
+rename (`BrailleGridFrames` → `BraillePatterns`) is not used by atunko.
+
+Verified before upgrading: the 0.4.0 test-fixtures artifacts (toolkit/tui/core) are
+published on Maven Central, and 0.4.0's `TestBackend.draw()` is still a no-op — the
+`PilotTestSupport` frame-capture harness remains necessary. 0.4.0's `EventRouter` still
+routes only left-button mouse presses, so the right-click limitation documented in the
+`tui-headless-testing` change is unchanged.
+
+## What Changes
+
+- `gradle/libs.versions.toml`: `tamboui = "0.3.0"` → `"0.4.0"` (single version bump; all
+  TamboUI modules resolve through the BOM)
+- No source changes expected; verified by full build and the complete test suite,
+  including the headless Pilot end-to-end tests from `tui-headless-testing`
+
+## Capabilities
+
+No capability changes — dependency maintenance only.
+
+## Impact
+
+- All modules consuming TamboUI (`atunko-tui`, transitively `atunko-cli`)
+- No reqstool changes; existing SVCs re-verified by the test suite

--- a/openspec/changes/tamboui-0.4.0-upgrade/tasks.md
+++ b/openspec/changes/tamboui-0.4.0-upgrade/tasks.md
@@ -1,0 +1,11 @@
+## 1. Upgrade
+
+- [x] 1.1 Bump `tamboui` to `0.4.0` in `gradle/libs.versions.toml`
+
+## 2. Verification
+
+- [x] 2.1 `./gradlew build` — compiles against 0.4.0, no Checkstyle/Error Prone violations
+- [x] 2.2 `./gradlew test` — all module tests pass, including `AtunkoTuiPilotTest`
+  headless end-to-end journeys (run 3× to check for timing regressions)
+- [x] 2.3 Manual smoke check not required — the Pilot tests cover launch, navigation,
+  search, selection, mouse, and overlay rendering end-to-end


### PR DESCRIPTION
## Summary

Bumps `tamboui` from 0.3.0 to 0.4.0 in the version catalog (all modules resolve through the BOM). **No source changes required.**

> **Stacked on #71** — based on `feat/tui-headless-testing` so the new headless Pilot end-to-end tests validate the upgrade. Merge #71 first; GitHub will retarget this PR to `main` automatically when the base branch is deleted.

## 0.4.0 relevance to atunko

- **Keyboard/bindings fixes**: `Builder.bindings()` propagation (semantic events like `isUp()`/`isSelect()` with custom binding sets), Shift+F1–F4 parsing, Windows arrow-key fix (Panama backend)
- **`ScrollableElement`**: built-in scrollable container with keyboard + mouse-wheel support — candidate for DetailView/FileDiffView scrolling later
- **Panel title alignment**, enhanced sparklines, `DualSparkline`, braille spinners
- Only rename (`BrailleGridFrames` → `BraillePatterns`) is unused by atunko

## Verified before/during upgrade

- 0.4.0 test-fixtures artifacts (toolkit/tui/core) published on Maven Central ✓
- `TestBackend.draw()` still a no-op in 0.4.0 — the frame-capture harness from #71 remains necessary
- `EventRouter` still routes only **left**-button mouse presses — right-click limitation unchanged (upstream)

## Test plan

- [x] `./gradlew build` — clean
- [x] `./gradlew :atunko-tui:test` ×3 — all pass incl. `AtunkoTuiPilotTest`, no timing flakes
- [x] `./gradlew test` — full suite green

https://claude.ai/code/session_01FXX3E17dP8gmu7aXNpxCxB